### PR TITLE
Rename service images to sbsp namespace

### DIFF
--- a/config-service/Jenkinsfile
+++ b/config-service/Jenkinsfile
@@ -15,7 +15,7 @@ node('dind-node') {
     stage('Image') {
       dir ('config-service') {
         docker.withRegistry('https://192.168.99.100:5000') {
-          def app = docker.build "piomin/config-service:${env.version}"
+          def app = docker.build "sbsp/config-service:${env.version}"
           app.push()
         }
       }

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -43,7 +43,7 @@
                                 <image>eclipse-temurin:21-jdk</image>
                             </from>
                             <to>
-                                <image>piomin/${project.artifactId}:${project.version}</image>
+                                <image>sbsp/${project.artifactId}:${project.version}</image>
                             </to>
                         </configuration>
                         <executions>

--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -119,7 +119,7 @@
                         <configuration>
                             <image>
                                 <builder>paketobuildpacks/builder-jammy-base:latest</builder>
-                                <name>piomin/${project.artifactId}:${project.version}</name>
+                                <name>sbsp/${project.artifactId}:${project.version}</name>
                             </image>
                         </configuration>
                         <executions>

--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -38,7 +38,7 @@
                                 <image>eclipse-temurin:21-jdk</image>
                             </from>
                             <to>
-                                <image>piomin/${project.artifactId}:${project.version}</image>
+                                <image>sbsp/${project.artifactId}:${project.version}</image>
                             </to>
                         </configuration>
                         <executions>
@@ -55,7 +55,7 @@
                     <!--						<artifactId>spring-boot-maven-plugin</artifactId>-->
                     <!--						<configuration>-->
                     <!--							<image>-->
-                    <!--								<name>piomin/${project.artifactId}:${project.version}</name>-->
+                    <!--								<name>sbsp/${project.artifactId}:${project.version}</name>-->
                     <!--							</image>-->
                     <!--						</configuration>-->
                     <!--						<executions>-->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "9411:9411"
   config-service:
-    image: piomin/config-service:1.1-SNAPSHOT
+    image: sbsp/config-service:1.1-SNAPSHOT
     ports:
       - "8088:8088"
     healthcheck:
@@ -16,7 +16,7 @@ services:
       timeout: 2s
       retries: 3
   discovery-service:
-    image: piomin/discovery-service:1.1-SNAPSHOT
+    image: sbsp/discovery-service:1.1-SNAPSHOT
     ports:
       - "8061:8061"
     depends_on:
@@ -32,7 +32,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
   employee-service:
-    image: piomin/employee-service:1.2-SNAPSHOT
+    image: sbsp/employee-service:1.2-SNAPSHOT
     ports:
       - "8080"
     depends_on:
@@ -45,7 +45,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
   department-service:
-    image: piomin/department-service:1.2-SNAPSHOT
+    image: sbsp/department-service:1.2-SNAPSHOT
     ports:
       - "8080"
     depends_on:
@@ -59,7 +59,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
   organization-service:
-    image: piomin/organization-service:1.2-SNAPSHOT
+    image: sbsp/organization-service:1.2-SNAPSHOT
     ports:
       - "8080"
     depends_on:
@@ -74,7 +74,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
   gateway-service:
-    image: piomin/gateway-service:1.1-SNAPSHOT
+    image: sbsp/gateway-service:1.1-SNAPSHOT
     ports:
       - "8060:8060"
     depends_on:

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -111,7 +111,7 @@
                         <configuration>
                             <image>
                                 <builder>paketobuildpacks/builder-jammy-base:latest</builder>
-                                <name>piomin/${project.artifactId}:${project.version}</name>
+                                <name>sbsp/${project.artifactId}:${project.version}</name>
                             </image>
                         </configuration>
                         <executions>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -65,7 +65,7 @@
                         <configuration>
                             <image>
                                 <builder>paketobuildpacks/builder-jammy-base:latest</builder>
-                                <name>piomin/${project.artifactId}:${project.version}</name>
+                                <name>sbsp/${project.artifactId}:${project.version}</name>
                             </image>
                         </configuration>
                         <executions>

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -101,7 +101,7 @@
                         <configuration>
                             <image>
                                 <builder>paketobuildpacks/builder-jammy-base:latest</builder>
-                                <name>piomin/${project.artifactId}:${project.version}</name>
+                                <name>sbsp/${project.artifactId}:${project.version}</name>
                             </image>
                         </configuration>
                         <executions>


### PR DESCRIPTION
## Summary
- use sbsp namespace for service images
- update config-service Jenkins pipeline to build sbsp image

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*


------
https://chatgpt.com/codex/tasks/task_e_6892be2d8c1c832d81b7dc7fb0c5adef