### PR TITLE
chore: rename project to spring-boot-subscription-platform

### DIFF
--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>config-service</artifactId>

--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>department-service</artifactId>

--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>discovery-service</artifactId>

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>employee-service</artifactId>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-service</artifactId>

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>morning.com.services</groupId>
-        <artifactId>sample-spring-microservices-new</artifactId>
+        <artifactId>spring-boot-subscription-platform</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>organization-service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <groupId>morning.com.services</groupId>
-    <artifactId>sample-spring-microservices-new</artifactId>
+    <artifactId>spring-boot-subscription-platform</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -19,8 +19,8 @@
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spring-openai-mvc.version>2.8.9</spring-openai-mvc.version>
         <spring-openai-flux.version>2.8.9</spring-openai-flux.version>
-        <sonar.projectKey>piomin_sample-spring-microservices-new</sonar.projectKey>
-        <sonar.organization>piomin</sonar.organization>
+        <sonar.projectKey>sbsp_spring-boot-subscription-platform</sonar.projectKey>
+        <sonar.organization>sbsp</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,3 @@ spring-boot-subscription-platform/
 ## Author
 
 Built and maintained by **Lucas** — a backend developer passionate about scalable SaaS, clean code, and great architecture.
-
-## REF
-https://github.com/piomin/sample-spring-microservices-new


### PR DESCRIPTION
## Summary
- rename parent artifact to spring-boot-subscription-platform and update sonar details
- update module poms to use new parent artifact
- remove outdated reference to sample project from README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68931669d740832d9e17fe9c16a60917