### PR TITLE
Add auth-service configuration to config service

### DIFF
--- a/config-service/src/main/resources/config/auth-service-docker.yml
+++ b/config-service/src/main/resources/config/auth-service-docker.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8080
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://discovery-service:8061/eureka/
+
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%X{traceId:-},%X{spanId:-}] ${LOG_LEVEL_PATTERN:-%5p} %m%n"
+
+springdoc:
+  packagesToScan: morning.com.services.auth
+
+spring:
+  output:
+    ansi:
+      enabled: always
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin:9411/api/v2/spans

--- a/config-service/src/main/resources/config/auth-service.yml
+++ b/config-service/src/main/resources/config/auth-service.yml
@@ -1,0 +1,36 @@
+server:
+  port: 0
+  forward-headers-strategy: framework
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8061/eureka/
+  instance:
+    instanceId: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+logging:
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){blue} %clr([%X{traceId:-},%X{spanId:-}]){cyan} %clr(${LOG_LEVEL_PATTERN:-%5p}) %m%n"
+
+springdoc:
+  packagesToScan: morning.com.services.auth
+  cache:
+    disabled: true
+  version: '@springdoc.version@'
+  api-docs:
+    version: openapi_3_1
+
+spring:
+  output:
+    ansi:
+      enabled: always
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  endpoints:
+    web:
+      exposure:
+        include: health,sbom


### PR DESCRIPTION
## Summary
- add missing auth-service configuration files for local and docker profiles

## Testing
- `mvn -q -pl config-service,auth-service test` *(fails: Non-resolvable parent POM; network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68932f1294bc832d89c66b0e4d8edecd