### PR TITLE
Preserve /auth prefix for auth-service route

### DIFF
--- a/config-service/src/main/resources/config/gateway-service-docker.yml
+++ b/config-service/src/main/resources/config/gateway-service-docker.yml
@@ -24,8 +24,6 @@ spring:
         uri: lb://auth-service
         predicates:
           - Path=/auth/**
-        filters:
-          - RewritePath=/auth/(?<path>.*), /\${path}
       - id: employee-service
         uri: lb://employee-service
         predicates:

--- a/config-service/src/main/resources/config/gateway-service.yml
+++ b/config-service/src/main/resources/config/gateway-service.yml
@@ -25,8 +25,6 @@ spring:
         uri: lb://auth-service
         predicates:
           - Path=/auth/**
-        filters:
-          - RewritePath=/auth/(?<path>.*), /\${path}
       - id: employee-service
         uri: lb://employee-service
         predicates:


### PR DESCRIPTION
## Summary
- ensure gateway forwards auth-service requests with `/auth` prefix intact

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68933c9cb824832d84204a9aa87b481d