### PR TITLE
feat: use MySQL for auth-service

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -43,6 +43,21 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-otel</artifactId>
         </dependency>

--- a/auth-service/src/main/java/morning/com/services/auth/model/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/model/User.java
@@ -1,25 +1,26 @@
 package morning.com.services.auth.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "users")
 public class User {
-    private final String id;
-    private final String username;
-    private final String passwordHash;
+    @Id
+    private String id;
 
-    public User(String id, String username, String passwordHash) {
-        this.id = id;
-        this.username = username;
-        this.passwordHash = passwordHash;
-    }
+    @Column(nullable = false, unique = true)
+    private String username;
 
-    public String getId() {
-        return id;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPasswordHash() {
-        return passwordHash;
-    }
+    @Column(nullable = false)
+    private String passwordHash;
 }

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package morning.com.services.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import morning.com.services.auth.model.User;
+
+public interface UserRepository extends CrudRepository<User, String> {
+    boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
+}
+

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -1,30 +1,34 @@
 package morning.com.services.auth.service;
 
 import morning.com.services.auth.model.User;
+import morning.com.services.auth.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class UserService {
-    private final Map<String, User> users = new ConcurrentHashMap<>();
+    private final UserRepository repository;
     private final PasswordEncoder encoder = new BCryptPasswordEncoder();
 
+    public UserService(UserRepository repository) {
+        this.repository = repository;
+    }
+
     public void register(String username, String password) {
-        if (users.containsKey(username)) {
+        if (repository.existsByUsername(username)) {
             throw new IllegalArgumentException("User already exists");
         }
         String id = UUID.randomUUID().toString();
         String hash = encoder.encode(password);
-        users.put(username, new User(id, username, hash));
+        repository.save(new User(id, username, hash));
     }
 
     public boolean authenticate(String username, String password) {
-        User user = users.get(username);
-        return user != null && encoder.matches(password, user.getPasswordHash());
+        return repository.findByUsername(username)
+                .map(user -> encoder.matches(password, user.getPasswordHash()))
+                .orElse(false);
     }
 }

--- a/config-service/src/main/resources/config/auth-service-docker.yml
+++ b/config-service/src/main/resources/config/auth-service-docker.yml
@@ -17,6 +17,16 @@ spring:
   output:
     ansi:
       enabled: always
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://auth-db:3306/authdb}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:password}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/auth-service.yml
+++ b/config-service/src/main/resources/config/auth-service.yml
@@ -25,6 +25,16 @@ spring:
   output:
     ansi:
       enabled: always
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/authdb}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:password}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
 management:
   tracing:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,13 @@ services:
       - zipkin
     environment:
       SPRING_PROFILES_ACTIVE: docker
+  auth-db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: authdb
+    ports:
+      - "3306:3306"
   auth-service:
     image: sbsp/auth-service:1.1-SNAPSHOT
     ports:
@@ -80,10 +87,13 @@ services:
     depends_on:
       discovery-service:
         condition: service_healthy
+      auth-db:
+        condition: service_started
     links:
       - config-service
       - discovery-service
       - zipkin
+      - auth-db
     environment:
       SPRING_PROFILES_ACTIVE: docker
   gateway-service:


### PR DESCRIPTION
## Summary
- persist auth-service users with Spring Data JPA and a MySQL backend
- wire a UserRepository and switch service logic from in-memory map to database
- add MySQL container and datasource configuration to docker-compose and application.yml
- reduce User entity boilerplate with Lombok and centralize datasource config in config-service

## Testing
- `mvn -q -pl auth-service,config-service test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689414b018ac832d88eb479e04b457aa