### PR TITLE
test(auth): replace integration test with Mockito

### DIFF
--- a/auth-service/src/test/java/morning/com/services/auth/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/AuthControllerTest.java
@@ -1,32 +1,47 @@
 package morning.com.services.auth;
 
+import morning.com.services.auth.controller.AuthController;
 import morning.com.services.auth.model.AuthRequest;
 import morning.com.services.auth.model.AuthResponse;
+import morning.com.services.auth.service.JwtService;
+import morning.com.services.auth.service.UserService;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
 
-    @Autowired
-    private TestRestTemplate restTemplate;
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private AuthController authController;
 
     @Test
     void registerAndLogin() {
         AuthRequest request = new AuthRequest("user", "password");
-        ResponseEntity<Void> registerResponse = restTemplate.postForEntity("/auth/register", request, Void.class);
-        assertEquals(HttpStatus.OK, registerResponse.getStatusCode());
 
-        ResponseEntity<AuthResponse> loginResponse = restTemplate.postForEntity("/auth/login", request, AuthResponse.class);
+        ResponseEntity<Void> registerResponse = authController.register(request);
+        assertEquals(HttpStatus.OK, registerResponse.getStatusCode());
+        verify(userService).register("user", "password");
+
+        when(userService.authenticate("user", "password")).thenReturn(true);
+        when(jwtService.generateToken("user")).thenReturn("token123");
+
+        ResponseEntity<AuthResponse> loginResponse = authController.login(request);
         assertEquals(HttpStatus.OK, loginResponse.getStatusCode());
         assertNotNull(loginResponse.getBody());
-        assertNotNull(loginResponse.getBody().token());
-        assertFalse(loginResponse.getBody().token().isBlank());
+        assertEquals("token123", loginResponse.getBody().token());
     }
 }


### PR DESCRIPTION
## Summary
- remove in-memory H2 test profile and dependency
- rewrite AuthControllerTest as a Mockito unit test

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68942c4b6420832d925af4d1257892ca