### PR TITLE
chore: update Mockito dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spring-openai-mvc.version>2.8.9</spring-openai-mvc.version>
         <spring-openai-flux.version>2.8.9</spring-openai-flux.version>
+        <mockito.version>5.12.0</mockito.version>
         <sonar.projectKey>sbsp_spring-boot-subscription-platform</sonar.projectKey>
         <sonar.organization>sbsp</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -42,6 +43,18 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spring-openai-mvc.version>2.8.9</spring-openai-mvc.version>
         <spring-openai-flux.version>2.8.9</spring-openai-flux.version>
-        <mockito.version>5.12.0</mockito.version>
+        <mockito.version>5.14.1</mockito.version>
         <sonar.projectKey>sbsp_spring-boot-subscription-platform</sonar.projectKey>
         <sonar.organization>sbsp</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -44,20 +44,23 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
## Summary
- define mockito.version property
- align mockito-core and mockito-junit-jupiter on the latest version

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689432996748832dba6612435942fe79