### PR TITLE
feat: standardize auth responses with ApiResponse

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package morning.com.services.auth.controller;
 
+import morning.com.services.auth.model.ApiResponse;
 import morning.com.services.auth.model.AuthRequest;
 import morning.com.services.auth.model.AuthResponse;
+import morning.com.services.auth.model.ResultEnum;
 import morning.com.services.auth.service.JwtService;
 import morning.com.services.auth.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -24,21 +26,23 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<Void> register(@RequestBody AuthRequest request) {
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody AuthRequest request) {
         try {
             userService.register(request.username(), request.password());
-            return ResponseEntity.ok().build();
+            return ResponseEntity.ok(ApiResponse.ok("User registered successfully"));
         } catch (IllegalArgumentException ex) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.error(ResultEnum.USERNAME_EXISTS));
         }
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody AuthRequest request) {
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@RequestBody AuthRequest request) {
         if (userService.authenticate(request.username(), request.password())) {
             String token = jwtService.generateToken(request.username());
-            return ResponseEntity.ok(new AuthResponse(token));
+            return ResponseEntity.ok(ApiResponse.ok(new AuthResponse(token)));
         }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(ResultEnum.INVALID_CREDENTIALS));
     }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/model/ApiResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/model/ApiResponse.java
@@ -1,0 +1,71 @@
+package morning.com.services.auth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Response wrapper for API results, including code, message, and optional data.
+ * Provides factory methods for various success and error responses.
+ *
+ * @author Lucas
+ * @param <T> the type of the response data
+ */
+@Data
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private int code;
+    private String message;
+    private T data;
+
+    // Constructor for responses without data
+    public ApiResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+        this.data = null;
+    }
+
+    // Factory method for success with data, using default success message
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessage(), data);
+    }
+
+    // Factory method for success with enum message and data
+    public static <T> ApiResponse<T> ok(ResultEnum messageEnum, T data) {
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage(), data);
+    }
+
+    // Factory method for success with custom message and data
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), message, data);
+    }
+
+    // Factory method for success without data and with default success message
+    public static <T> ApiResponse<T> ok() {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessage(), null);
+    }
+
+    // Factory method for success without data and with a custom message
+    public static <T> ApiResponse<T> ok(String message) {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), message, null);
+    }
+
+    // Factory method for error with enum message
+    public static <T> ApiResponse<T> error(ResultEnum messageEnum) {
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage());
+    }
+
+    // Factory method for error with custom message
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(ResultEnum.ERROR.getCode(), message);
+    }
+
+    // Factory method for error with enum message and data
+    public static <T> ApiResponse<T> error(ResultEnum messageEnum, T data) {
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage(), data);
+    }
+
+    // Factory method for error with custom message and data
+    public static <T> ApiResponse<T> error(String message, T data) {
+        return new ApiResponse<>(ResultEnum.ERROR.getCode(), message, data);
+    }
+}

--- a/auth-service/src/main/java/morning/com/services/auth/model/ResultEnum.java
+++ b/auth-service/src/main/java/morning/com/services/auth/model/ResultEnum.java
@@ -1,0 +1,27 @@
+package morning.com.services.auth.model;
+
+/**
+ * Standard result codes and messages for API responses.
+ */
+public enum ResultEnum {
+    SUCCESS(200, "Success"),
+    ERROR(500, "Error"),
+    USERNAME_EXISTS(409, "Username already exists"),
+    INVALID_CREDENTIALS(401, "Invalid credentials");
+
+    private final int code;
+    private final String message;
+
+    ResultEnum(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## Summary
- add generic `ApiResponse<T>` class with code, message, and data fields plus success/error factory helpers
- introduce `ResultEnum` for common auth success and error codes
- refactor `AuthController` so register/login endpoints return `ApiResponse`

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894555e3b98832daff397fbf3d9c823