### PR TITLE
refactor: organize auth-service packages

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -1,9 +1,9 @@
 package morning.com.services.auth.controller;
 
-import morning.com.services.auth.model.ApiResponse;
-import morning.com.services.auth.model.AuthRequest;
-import morning.com.services.auth.model.AuthResponse;
-import morning.com.services.auth.model.ResultEnum;
+import morning.com.services.auth.dto.ApiResponse;
+import morning.com.services.auth.dto.AuthRequest;
+import morning.com.services.auth.dto.AuthResponse;
+import morning.com.services.auth.dto.ResultEnum;
 import morning.com.services.auth.service.JwtService;
 import morning.com.services.auth.service.UserService;
 import org.springframework.http.HttpStatus;

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
@@ -1,4 +1,4 @@
-package morning.com.services.auth.model;
+package morning.com.services.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/auth-service/src/main/java/morning/com/services/auth/dto/AuthRequest.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/AuthRequest.java
@@ -1,4 +1,4 @@
-package morning.com.services.auth.model;
+package morning.com.services.auth.dto;
 
 public record AuthRequest(String username, String password) {
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
@@ -1,4 +1,4 @@
-package morning.com.services.auth.model;
+package morning.com.services.auth.dto;
 
 public record AuthResponse(String token) {
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
@@ -1,4 +1,4 @@
-package morning.com.services.auth.model;
+package morning.com.services.auth.dto;
 
 /**
  * Standard result codes and messages for API responses.

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -1,4 +1,4 @@
-package morning.com.services.auth.model;
+package morning.com.services.auth.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 
-import morning.com.services.auth.model.User;
+import morning.com.services.auth.entity.User;
 
 public interface UserRepository extends CrudRepository<User, String> {
     boolean existsByUsername(String username);

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -1,6 +1,6 @@
 package morning.com.services.auth.service;
 
-import morning.com.services.auth.model.User;
+import morning.com.services.auth.entity.User;
 import morning.com.services.auth.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -1,9 +1,9 @@
 package morning.com.services.auth.controller;
 
-import morning.com.services.auth.model.ApiResponse;
-import morning.com.services.auth.model.AuthRequest;
-import morning.com.services.auth.model.AuthResponse;
-import morning.com.services.auth.model.ResultEnum;
+import morning.com.services.auth.dto.ApiResponse;
+import morning.com.services.auth.dto.AuthRequest;
+import morning.com.services.auth.dto.AuthResponse;
+import morning.com.services.auth.dto.ResultEnum;
 import morning.com.services.auth.service.JwtService;
 import morning.com.services.auth.service.UserService;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- move User to entity package and place API request/response records in dto package
- update controller, repository, service, and tests to use new entity and dto packages
- keep application.yml under src/main/resources

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689465f16300832da3d01f045af0becf