### PR TITLE
Refactor auth-service to return message keys

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,49 @@
+# Auth Service
+
+The auth service returns message keys instead of translated text in API responses. Consumers should translate these keys on the client side using their preferred i18n library.
+
+## Response format
+
+```json
+{
+  "code": 401,
+  "messageKey": "auth.invalid.credentials",
+  "data": null
+}
+```
+
+### Validation error example
+
+```json
+{
+  "code": 400,
+  "messageKey": "validation.error",
+  "data": null
+}
+```
+
+### Translating message keys on the frontend
+
+```javascript
+import { t } from 'i18next';
+
+fetch('/auth/login', options)
+  .then(res => res.json())
+  .then(body => {
+    const message = t(body.messageKey);
+    console.log(message);
+  });
+```
+
+Define the message keys in your translation files:
+
+```json
+{
+  "auth.invalid.credentials": "Invalid username or password",
+  "auth.username.exists": "Username already exists",
+  "auth.register.success": "Registration successful",
+  "validation.error": "Please correct the highlighted fields."
+}
+```
+
+This keeps the backend language-agnostic while allowing the frontend to localize messages for each user.

--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody AuthRequest request) {
         try {
             userService.register(request.username(), request.password());
-            return ResponseEntity.ok(ApiResponse.ok("User registered successfully"));
+            return ResponseEntity.ok(ApiResponse.ok(ResultEnum.USER_REGISTERED));
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(ApiResponse.error(ResultEnum.USERNAME_EXISTS));

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- * Response wrapper for API results, including code, message, and optional data.
+ * Response wrapper for API results, including code, message key, and optional data.
  * Provides factory methods for various success and error responses.
  *
  * @author Lucas
@@ -14,58 +14,63 @@ import lombok.Data;
 @AllArgsConstructor
 public class ApiResponse<T> {
     private int code;
-    private String message;
+    private String messageKey;
     private T data;
 
     // Constructor for responses without data
-    public ApiResponse(int code, String message) {
+    public ApiResponse(int code, String messageKey) {
         this.code = code;
-        this.message = message;
+        this.messageKey = messageKey;
         this.data = null;
     }
 
-    // Factory method for success with data, using default success message
+    // Factory method for success with data, using default success message key
     public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessage(), data);
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessageKey(), data);
     }
 
-    // Factory method for success with enum message and data
+    // Factory method for success with enum message key and data
     public static <T> ApiResponse<T> ok(ResultEnum messageEnum, T data) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage(), data);
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), data);
     }
 
-    // Factory method for success with custom message and data
-    public static <T> ApiResponse<T> ok(String message, T data) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), message, data);
+    // Factory method for success with custom message key and data
+    public static <T> ApiResponse<T> ok(String messageKey, T data) {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), messageKey, data);
     }
 
-    // Factory method for success without data and with default success message
+    // Factory method for success without data using enum message key
+    public static <T> ApiResponse<T> ok(ResultEnum messageEnum) {
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), null);
+    }
+
+    // Factory method for success without data and with default success message key
     public static <T> ApiResponse<T> ok() {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessage(), null);
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessageKey(), null);
     }
 
-    // Factory method for success without data and with a custom message
-    public static <T> ApiResponse<T> ok(String message) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), message, null);
+    // Factory method for success without data and with a custom message key
+    public static <T> ApiResponse<T> ok(String messageKey) {
+        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), messageKey, null);
     }
 
-    // Factory method for error with enum message
+    // Factory method for error with enum message key
     public static <T> ApiResponse<T> error(ResultEnum messageEnum) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage());
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey());
     }
 
-    // Factory method for error with custom message
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(ResultEnum.ERROR.getCode(), message);
+    // Factory method for error with custom message key
+    public static <T> ApiResponse<T> error(String messageKey) {
+        return new ApiResponse<>(ResultEnum.ERROR.getCode(), messageKey);
     }
 
-    // Factory method for error with enum message and data
+    // Factory method for error with enum message key and data
     public static <T> ApiResponse<T> error(ResultEnum messageEnum, T data) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessage(), data);
+        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), data);
     }
 
-    // Factory method for error with custom message and data
-    public static <T> ApiResponse<T> error(String message, T data) {
-        return new ApiResponse<>(ResultEnum.ERROR.getCode(), message, data);
+    // Factory method for error with custom message key and data
+    public static <T> ApiResponse<T> error(String messageKey, T data) {
+        return new ApiResponse<>(ResultEnum.ERROR.getCode(), messageKey, data);
     }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
@@ -1,27 +1,29 @@
 package morning.com.services.auth.dto;
 
 /**
- * Standard result codes and messages for API responses.
+ * Standard result codes and message keys for API responses.
  */
 public enum ResultEnum {
-    SUCCESS(200, "Success"),
-    ERROR(500, "Error"),
-    USERNAME_EXISTS(409, "Username already exists"),
-    INVALID_CREDENTIALS(401, "Invalid credentials");
+    SUCCESS(200, "auth.success"),
+    ERROR(500, "auth.error"),
+    USER_REGISTERED(200, "auth.register.success"),
+    USERNAME_EXISTS(409, "auth.username.exists"),
+    INVALID_CREDENTIALS(401, "auth.invalid.credentials"),
+    VALIDATION_ERROR(400, "validation.error");
 
     private final int code;
-    private final String message;
+    private final String messageKey;
 
-    ResultEnum(int code, String message) {
+    ResultEnum(int code, String messageKey) {
         this.code = code;
-        this.message = message;
+        this.messageKey = messageKey;
     }
 
     public int getCode() {
         return code;
     }
 
-    public String getMessage() {
-        return message;
+    public String getMessageKey() {
+        return messageKey;
     }
 }

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -37,8 +37,8 @@ class AuthControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ResultEnum.SUCCESS.getCode(), body.getCode());
-        assertEquals("User registered successfully", body.getMessage());
+        assertEquals(ResultEnum.USER_REGISTERED.getCode(), body.getCode());
+        assertEquals(ResultEnum.USER_REGISTERED.getMessageKey(), body.getMessageKey());
         verify(userService).register("user", "password");
     }
 
@@ -53,7 +53,7 @@ class AuthControllerTest {
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
         assertEquals(ResultEnum.USERNAME_EXISTS.getCode(), body.getCode());
-        assertEquals(ResultEnum.USERNAME_EXISTS.getMessage(), body.getMessage());
+        assertEquals(ResultEnum.USERNAME_EXISTS.getMessageKey(), body.getMessageKey());
     }
 
     @Test
@@ -67,6 +67,7 @@ class AuthControllerTest {
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
         assertEquals(ResultEnum.SUCCESS.getCode(), body.getCode());
+        assertEquals(ResultEnum.SUCCESS.getMessageKey(), body.getMessageKey());
         assertNotNull(body.getData());
         assertEquals("token123", body.getData().token());
     }
@@ -81,7 +82,7 @@ class AuthControllerTest {
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
         assertEquals(ResultEnum.INVALID_CREDENTIALS.getCode(), body.getCode());
-        assertEquals(ResultEnum.INVALID_CREDENTIALS.getMessage(), body.getMessage());
+        assertEquals(ResultEnum.INVALID_CREDENTIALS.getMessageKey(), body.getMessageKey());
         assertNull(body.getData());
     }
 }


### PR DESCRIPTION
## Summary
- Refactor ApiResponse to expose a `messageKey` field and provide factory helpers for message keys.
- Replace translated strings with message-key enums for registration, credential errors, username clashes, and validation errors.
- Document message key responses and show how to translate them on the frontend using i18n.

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM - network is unreachable)*
- `mvn -q -pl auth-service -o test` *(fails: Non-resolvable parent POM - artifact has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_689474ffdeac832db3a54a9ab5709a8c