### PR TITLE
refactor: standardize auth-service responses

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody AuthRequest request) {
         try {
             userService.register(request.username(), request.password());
-            return ResponseEntity.ok(ApiResponse.ok(ResultEnum.USER_REGISTERED));
+            return ResponseEntity.ok(ApiResponse.success(ResultEnum.USER_REGISTERED));
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(ApiResponse.error(ResultEnum.USERNAME_EXISTS));
@@ -40,7 +40,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<AuthResponse>> login(@RequestBody AuthRequest request) {
         if (userService.authenticate(request.username(), request.password())) {
             String token = jwtService.generateToken(request.username());
-            return ResponseEntity.ok(ApiResponse.ok(new AuthResponse(token)));
+            return ResponseEntity.ok(ApiResponse.success(ResultEnum.SUCCESS, new AuthResponse(token)));
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.error(ResultEnum.INVALID_CREDENTIALS));

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- * Response wrapper for API results, including code, message key, and optional data.
+ * Response wrapper for API results, including status, message key, and optional data.
  * Provides factory methods for various success and error responses.
  *
  * @author Lucas
@@ -13,64 +13,64 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class ApiResponse<T> {
-    private int code;
+    private String status;
     private String messageKey;
     private T data;
 
     // Constructor for responses without data
-    public ApiResponse(int code, String messageKey) {
-        this.code = code;
+    public ApiResponse(String status, String messageKey) {
+        this.status = status;
         this.messageKey = messageKey;
         this.data = null;
     }
 
     // Factory method for success with data, using default success message key
-    public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessageKey(), data);
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", ResultEnum.SUCCESS.getMessageKey(), data);
     }
 
     // Factory method for success with enum message key and data
-    public static <T> ApiResponse<T> ok(ResultEnum messageEnum, T data) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), data);
+    public static <T> ApiResponse<T> success(ResultEnum messageEnum, T data) {
+        return new ApiResponse<>("success", messageEnum.getMessageKey(), data);
     }
 
     // Factory method for success with custom message key and data
-    public static <T> ApiResponse<T> ok(String messageKey, T data) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), messageKey, data);
+    public static <T> ApiResponse<T> success(String messageKey, T data) {
+        return new ApiResponse<>("success", messageKey, data);
     }
 
     // Factory method for success without data using enum message key
-    public static <T> ApiResponse<T> ok(ResultEnum messageEnum) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), null);
+    public static <T> ApiResponse<T> success(ResultEnum messageEnum) {
+        return new ApiResponse<>("success", messageEnum.getMessageKey(), null);
     }
 
     // Factory method for success without data and with default success message key
-    public static <T> ApiResponse<T> ok() {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), ResultEnum.SUCCESS.getMessageKey(), null);
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>("success", ResultEnum.SUCCESS.getMessageKey(), null);
     }
 
     // Factory method for success without data and with a custom message key
-    public static <T> ApiResponse<T> ok(String messageKey) {
-        return new ApiResponse<>(ResultEnum.SUCCESS.getCode(), messageKey, null);
+    public static <T> ApiResponse<T> success(String messageKey) {
+        return new ApiResponse<>("success", messageKey, null);
     }
 
     // Factory method for error with enum message key
     public static <T> ApiResponse<T> error(ResultEnum messageEnum) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey());
+        return new ApiResponse<>("error", messageEnum.getMessageKey());
     }
 
     // Factory method for error with custom message key
     public static <T> ApiResponse<T> error(String messageKey) {
-        return new ApiResponse<>(ResultEnum.ERROR.getCode(), messageKey);
+        return new ApiResponse<>("error", messageKey);
     }
 
     // Factory method for error with enum message key and data
     public static <T> ApiResponse<T> error(ResultEnum messageEnum, T data) {
-        return new ApiResponse<>(messageEnum.getCode(), messageEnum.getMessageKey(), data);
+        return new ApiResponse<>("error", messageEnum.getMessageKey(), data);
     }
 
     // Factory method for error with custom message key and data
     public static <T> ApiResponse<T> error(String messageKey, T data) {
-        return new ApiResponse<>(ResultEnum.ERROR.getCode(), messageKey, data);
+        return new ApiResponse<>("error", messageKey, data);
     }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ResultEnum.java
@@ -1,26 +1,19 @@
 package morning.com.services.auth.dto;
 
 /**
- * Standard result codes and message keys for API responses.
+ * Standard message keys for API responses.
  */
 public enum ResultEnum {
-    SUCCESS(200, "auth.success"),
-    ERROR(500, "auth.error"),
-    USER_REGISTERED(200, "auth.register.success"),
-    USERNAME_EXISTS(409, "auth.username.exists"),
-    INVALID_CREDENTIALS(401, "auth.invalid.credentials"),
-    VALIDATION_ERROR(400, "validation.error");
+    SUCCESS("auth.success"),
+    USER_REGISTERED("auth.register.success"),
+    USERNAME_EXISTS("auth.username.exists"),
+    INVALID_CREDENTIALS("auth.invalid.credentials"),
+    VALIDATION_ERROR("validation.error");
 
-    private final int code;
     private final String messageKey;
 
-    ResultEnum(int code, String messageKey) {
-        this.code = code;
+    ResultEnum(String messageKey) {
         this.messageKey = messageKey;
-    }
-
-    public int getCode() {
-        return code;
     }
 
     public String getMessageKey() {

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -1,5 +1,6 @@
 package morning.com.services.auth.service;
 
+import morning.com.services.auth.dto.ResultEnum;
 import morning.com.services.auth.entity.User;
 import morning.com.services.auth.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,7 +20,7 @@ public class UserService {
 
     public void register(String username, String password) {
         if (repository.existsByUsername(username)) {
-            throw new IllegalArgumentException("User already exists");
+            throw new IllegalArgumentException(ResultEnum.USERNAME_EXISTS.getMessageKey());
         }
         String id = UUID.randomUUID().toString();
         String hash = encoder.encode(password);

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -37,7 +37,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ResultEnum.USER_REGISTERED.getCode(), body.getCode());
+        assertEquals("success", body.getStatus());
         assertEquals(ResultEnum.USER_REGISTERED.getMessageKey(), body.getMessageKey());
         verify(userService).register("user", "password");
     }
@@ -45,14 +45,14 @@ class AuthControllerTest {
     @Test
     void registerUsernameExists() {
         AuthRequest request = new AuthRequest("user", "password");
-        doThrow(new IllegalArgumentException("exists"))
+        doThrow(new IllegalArgumentException(ResultEnum.USERNAME_EXISTS.getMessageKey()))
                 .when(userService).register("user", "password");
 
         ResponseEntity<ApiResponse<Void>> response = authController.register(request);
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ResultEnum.USERNAME_EXISTS.getCode(), body.getCode());
+        assertEquals("error", body.getStatus());
         assertEquals(ResultEnum.USERNAME_EXISTS.getMessageKey(), body.getMessageKey());
     }
 
@@ -66,7 +66,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ResultEnum.SUCCESS.getCode(), body.getCode());
+        assertEquals("success", body.getStatus());
         assertEquals(ResultEnum.SUCCESS.getMessageKey(), body.getMessageKey());
         assertNotNull(body.getData());
         assertEquals("token123", body.getData().token());
@@ -81,7 +81,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ResultEnum.INVALID_CREDENTIALS.getCode(), body.getCode());
+        assertEquals("error", body.getStatus());
         assertEquals(ResultEnum.INVALID_CREDENTIALS.getMessageKey(), body.getMessageKey());
         assertNull(body.getData());
     }


### PR DESCRIPTION
## Summary
- refactor ApiResponse to use status, message key, and data
- ensure AuthController endpoints return standardized ApiResponse
- remove direct human-readable messages from UserService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68947cc89308832d9746874313b77f7f