### PR TITLE
Add production CORS configuration for gateway service

### DIFF
--- a/config-service/src/main/resources/config/gateway-service-docker.yml
+++ b/config-service/src/main/resources/config/gateway-service-docker.yml
@@ -1,6 +1,10 @@
 server:
   port: 8060
 
+app:
+  cors:
+    origins: https://app.example.com,https://admin.example.com
+
 eureka:
   client:
     serviceUrl:
@@ -16,6 +20,8 @@ spring:
       enabled: always
   cloud:
     gateway:
+      globalcors:
+        add-to-simple-url-handler-mapping: true
       discovery:
         locator:
           enabled: true

--- a/config-service/src/main/resources/config/gateway-service.yml
+++ b/config-service/src/main/resources/config/gateway-service.yml
@@ -2,6 +2,10 @@ server:
   port: 8060
   forward-headers-strategy: framework
 
+app:
+  cors:
+    origins: https://app.example.com,https://admin.example.com
+
 eureka:
   client:
     serviceUrl:
@@ -17,6 +21,8 @@ spring:
       enabled: always
   cloud:
     gateway:
+      globalcors:
+        add-to-simple-url-handler-mapping: true
       discovery:
         locator:
           enabled: true

--- a/gateway-service/src/main/java/morning/com/services/gateway/config/CorsConfig.java
+++ b/gateway-service/src/main/java/morning/com/services/gateway/config/CorsConfig.java
@@ -1,0 +1,58 @@
+package morning.com.services.gateway.config;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+public class CorsConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CorsConfig.class);
+
+    private final List<String> allowedOrigins;
+
+    public CorsConfig(@Value("${app.cors.origins:}") String origins) {
+        this.allowedOrigins = StringUtils.hasText(origins)
+                ? Arrays.stream(origins.split(","))
+                        .map(String::trim)
+                        .filter(StringUtils::hasText)
+                        .collect(Collectors.toList())
+                : List.of();
+    }
+
+    @PostConstruct
+    public void validateAndLogOrigins() {
+        if (allowedOrigins.isEmpty() || allowedOrigins.contains("*")) {
+            LOGGER.error("Invalid CORS configuration. Specify allowed origins in 'app.cors.origins' when credentials are allowed.");
+            throw new IllegalStateException("Invalid CORS configuration");
+        }
+        LOGGER.info("CORS allowed origins: {}", allowedOrigins);
+    }
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of(CorsConfiguration.ALL));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsWebFilter(source);
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure gateway-service CORS origins via config-service property
- add global CorsWebFilter with explicit origin validation and logging

## Testing
- `mvn -q -pl config-service,gateway-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6895a17eb718832d9a2388d44a44bdf7