### PR TITLE
feat(auth): expand user model with refresh tokens

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>9.4.0</version>

--- a/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
@@ -1,0 +1,46 @@
+package morning.com.services.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "refresh_tokens",
+        indexes = {
+                @Index(name = "ix_refresh_user", columnList = "user_id"),
+                @Index(name = "ix_refresh_expires", columnList = "expires_at")
+        })
+public class RefreshToken {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(nullable = false, length = 128)
+    private String tokenHash;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+
+    private Instant revokedAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(length = 45)
+    private String createdIp;
+
+    @Column(length = 255)
+    private String userAgent;
+}

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -1,24 +1,47 @@
 package morning.com.services.auth.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-@Table(name = "users", indexes = {
-        @Index(name = "ux_users_username", columnList = "username", unique = true)
-})
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_users_username", columnNames = "username"),
+                @UniqueConstraint(name = "ux_users_email", columnNames = "email")
+        },
+        indexes = {
+                @Index(name = "ix_users_lock_until", columnList = "lock_until"),
+                @Index(name = "ix_users_enabled", columnList = "enabled"),
+                @Index(name = "ix_users_last_login_at", columnList = "last_login_at")
+        })
 public class User {
     @Id
+    @Column(length = 36)
     private String id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 64)
     private String username;
 
+    @Column(unique = true, length = 190)
+    private String email;
+
     @Column(nullable = false)
+    private boolean emailVerified;
+
+    @Column(nullable = false, length = 100)
     private String passwordHash;
 
     @Setter
@@ -27,4 +50,55 @@ public class User {
 
     @Setter
     private Instant lockUntil;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @Setter
+    private Instant lastLoginAt;
+
+    @Setter
+    private Instant lastPasswordChangeAt;
+
+    @Column(length = 16)
+    private String locale;
+
+    @Column(length = 64)
+    private String timeZone;
+
+    @Column(nullable = false)
+    private boolean mfaEnabled;
+
+    @Column(length = 128)
+    private String totpSecret;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 32)
+    private Set<Role> roles = new HashSet<>();
+
+    public User(String id, String username, String email, String passwordHash) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.failedAttempts = 0;
+        this.emailVerified = false;
+        this.enabled = true;
+        this.mfaEnabled = false;
+    }
+
+    public enum Role {
+        USER,
+        ADMIN
+    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package morning.com.services.auth.repository;
+
+import morning.com.services.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    List<RefreshToken> findAllByUserId(String userId);
+    Optional<RefreshToken> findByIdAndUserId(String id, String userId);
+    long deleteByUserId(String userId);
+}

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -33,16 +34,20 @@ public class UserService {
 
     @Transactional
     public void register(String username, String password) {
-        if (repository.existsByUsername(username)) {
+        String normalized = username.toLowerCase(Locale.ROOT);
+        if (repository.existsByUsername(normalized)) {
             throw new IllegalArgumentException(MessageKeys.USERNAME_EXISTS);
         }
-        var id = UUID.randomUUID().toString();
-        var hash = encoder.encode(password);
-        repository.save(new User(id, username, hash, 0, null));
+        String id = UUID.randomUUID().toString();
+        String hash = encoder.encode(password);
+        User user = new User(id, normalized, null, hash);
+        user.getRoles().add(User.Role.USER);
+        repository.save(user);
     }
 
     public boolean authenticate(String username, String password) {
-        return repository.findByUsername(username)
+        String normalized = username.toLowerCase(Locale.ROOT);
+        return repository.findByUsername(normalized)
                 .map(u -> {
                     Instant now = Instant.now();
                     if (u.getLockUntil() != null && now.isBefore(u.getLockUntil())) {
@@ -52,6 +57,7 @@ public class UserService {
                     if (matches) {
                         u.setFailedAttempts(0);
                         u.setLockUntil(null);
+                        u.setLastLoginAt(now);
                         repository.save(u);
                         return true;
                     }
@@ -70,6 +76,10 @@ public class UserService {
     }
 
     public Optional<User> findByUsername(String username) {
-        return repository.findByUsername(username);
+        return repository.findByUsername(username.toLowerCase(Locale.ROOT));
+    }
+
+    public Optional<User> findByEmail(String email) {
+        return repository.findByEmail(email.toLowerCase(Locale.ROOT));
     }
 }

--- a/auth-service/src/main/resources/db/migration/V1__init.sql
+++ b/auth-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,68 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(36) NOT NULL,
+    username VARCHAR(64) NOT NULL,
+    email VARCHAR(190),
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    password_hash VARCHAR(100) NOT NULL,
+    failed_attempts INT NOT NULL DEFAULT 0,
+    lock_until TIMESTAMP NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    last_login_at TIMESTAMP NULL,
+    last_password_change_at TIMESTAMP NULL,
+    locale VARCHAR(16),
+    time_zone VARCHAR(64),
+    mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    totp_secret VARCHAR(128),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Ensure new columns exist when upgrading from older schema
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email VARCHAR(190),
+    ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS password_hash VARCHAR(100) NOT NULL,
+    ADD COLUMN IF NOT EXISTS failed_attempts INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS lock_until TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS last_password_change_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS locale VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS time_zone VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_users_username ON users(username);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS ix_users_lock_until ON users(lock_until);
+CREATE INDEX IF NOT EXISTS ix_users_enabled ON users(enabled);
+CREATE INDEX IF NOT EXISTS ix_users_last_login_at ON users(last_login_at);
+
+-- User roles table
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id VARCHAR(36) NOT NULL,
+    role VARCHAR(32) NOT NULL,
+    PRIMARY KEY (user_id, role),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Refresh tokens table
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id VARCHAR(36) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    token_hash VARCHAR(128) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    revoked_at TIMESTAMP NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_ip VARCHAR(45),
+    user_agent VARCHAR(255),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_refresh_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX IF NOT EXISTS ix_refresh_user ON refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS ix_refresh_expires ON refresh_tokens(expires_at);

--- a/auth-service/src/test/java/morning/com/services/auth/service/UserServiceTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/service/UserServiceTest.java
@@ -1,0 +1,49 @@
+package morning.com.services.auth.service;
+
+import morning.com.services.auth.config.SecurityBeans;
+import morning.com.services.auth.entity.User;
+import morning.com.services.auth.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({UserService.class, SecurityBeans.class})
+@TestPropertySource(properties = "spring.flyway.enabled=false")
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void registerPopulatesDefaults() {
+        userService.register("User", "password");
+        Optional<User> opt = userRepository.findByUsername("user");
+        assertTrue(opt.isPresent());
+        User u = opt.get();
+        assertEquals("user", u.getUsername());
+        assertTrue(u.isEnabled());
+        assertFalse(u.isEmailVerified());
+        assertEquals(0, u.getFailedAttempts());
+        assertNotNull(u.getCreatedAt());
+        assertNotNull(u.getUpdatedAt());
+        assertTrue(u.getRoles().contains(User.Role.USER));
+    }
+
+    @Test
+    void authenticateUpdatesLastLogin() {
+        userService.register("user", "password");
+        assertTrue(userService.authenticate("user", "password"));
+        User u = userRepository.findByUsername("user").orElseThrow();
+        assertNotNull(u.getLastLoginAt());
+    }
+}


### PR DESCRIPTION
## Summary
- enrich `User` entity with audit fields, MFA, locale, and role support
- introduce `RefreshToken` entity and repository for token renewal
- add Flyway migration and tests

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895baae74b4832db3642d001f47b0c5