### PR TITLE
feat(auth): add refresh tokens and enrich user model

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -47,6 +47,15 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>9.4.0</version>

--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Locale;
+
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -33,8 +35,9 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest request) {
-        if (userService.authenticate(request.username(), request.password())) {
-            String token = jwtService.generateToken(request.username());
+        String username = request.username().toLowerCase(Locale.ROOT);
+        if (userService.authenticate(username, request.password())) {
+            String token = jwtService.generateToken(username);
             long exp = jwtService.getExpiration(token).getTime();
             return ApiResponse.success(MessageKeys.SUCCESS, new AuthResponse(token, exp));
         }

--- a/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package morning.com.services.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "refresh_tokens",
+        indexes = {
+                @Index(name = "ix_refresh_user", columnList = "user_id"),
+                @Index(name = "ix_refresh_expires", columnList = "expires_at")
+        })
+public class RefreshToken {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "token_hash", nullable = false, length = 128)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "created_ip", length = 45)
+    private String createdIp;
+
+    @Column(name = "user_agent", length = 255)
+    private String userAgent;
+}

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -81,7 +81,7 @@ public class User {
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
-    @Column(name = "role")
+    @Column(name = "role", nullable = false, length = 32)
     private Set<Role> roles;
 
     public enum Role {

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -2,29 +2,89 @@ package morning.com.services.auth.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import java.time.Instant;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-@Table(name = "users", indexes = {
-        @Index(name = "ux_users_username", columnList = "username", unique = true)
-})
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_users_username", columnNames = "username"),
+                @UniqueConstraint(name = "ux_users_email", columnNames = "email")
+        },
+        indexes = {
+                @Index(name = "ix_users_lock_until", columnList = "lock_until"),
+                @Index(name = "ix_users_enabled", columnList = "enabled"),
+                @Index(name = "ix_users_last_login_at", columnList = "last_login_at")
+        })
 public class User {
     @Id
+    @Column(length = 36)
     private String id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, length = 64)
     private String username;
 
-    @Column(nullable = false)
+    @Column(length = 190)
+    private String email;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "password_hash", nullable = false, length = 100)
     private String passwordHash;
 
     @Setter
-    @Column(nullable = false)
+    @Column(name = "failed_attempts", nullable = false)
     private int failedAttempts;
 
     @Setter
+    @Column(name = "lock_until")
     private Instant lockUntil;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Setter
+    @Column(name = "last_login_at")
+    private Instant lastLoginAt;
+
+    @Setter
+    @Column(name = "last_password_change_at")
+    private Instant lastPasswordChangeAt;
+
+    @Column(length = 16)
+    private String locale;
+
+    @Column(name = "time_zone", length = 64)
+    private String timeZone;
+
+    @Column(name = "mfa_enabled", nullable = false)
+    private boolean mfaEnabled;
+
+    @Column(name = "totp_secret", length = 128)
+    private String totpSecret;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "role")
+    private Set<Role> roles;
+
+    public enum Role {
+        USER, ADMIN
+    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -7,7 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUsername(String username);
-    boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
-    Optional<User> findByEmail(String email);
 }

--- a/auth-service/src/main/resources/db/migration/V1__init.sql
+++ b/auth-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,46 @@
+CREATE TABLE users (
+    id VARCHAR(36) NOT NULL,
+    username VARCHAR(64) NOT NULL,
+    email VARCHAR(190),
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    password_hash VARCHAR(100) NOT NULL,
+    failed_attempts INT NOT NULL DEFAULT 0,
+    lock_until DATETIME NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    last_login_at DATETIME NULL,
+    last_password_change_at DATETIME NULL,
+    locale VARCHAR(16),
+    time_zone VARCHAR(64),
+    mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    totp_secret VARCHAR(128),
+    PRIMARY KEY (id),
+    UNIQUE KEY ux_users_username (username),
+    UNIQUE KEY ux_users_email (email),
+    KEY ix_users_lock_until (lock_until),
+    KEY ix_users_enabled (enabled),
+    KEY ix_users_last_login_at (last_login_at)
+);
+
+CREATE TABLE user_roles (
+    user_id VARCHAR(36) NOT NULL,
+    role VARCHAR(255) NOT NULL,
+    PRIMARY KEY (user_id, role),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE refresh_tokens (
+    id VARCHAR(36) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    token_hash VARCHAR(128) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_ip VARCHAR(45),
+    user_agent VARCHAR(255),
+    PRIMARY KEY (id),
+    KEY ix_refresh_user (user_id),
+    KEY ix_refresh_expires (expires_at),
+    CONSTRAINT fk_refresh_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/auth-service/src/main/resources/db/migration/V1__init.sql
+++ b/auth-service/src/main/resources/db/migration/V1__init.sql
@@ -25,7 +25,7 @@ CREATE TABLE users (
 
 CREATE TABLE user_roles (
     user_id VARCHAR(36) NOT NULL,
-    role VARCHAR(255) NOT NULL,
+    role VARCHAR(32) NOT NULL,
     PRIMARY KEY (user_id, role),
     CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## Summary
- extend User with email, locale, MFA, timestamps and roles
- add RefreshToken entity for hashed refresh tokens
- enable Flyway migrations and create initial schema

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_6895c6fbe758832d8c6f5d230667a6a0