### PR TITLE
feat(auth): add refresh tokens and enrich user

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
@@ -3,9 +3,11 @@ package morning.com.services.auth.dto;
 public record AuthResponse(
         String token,
         long expiresAtEpochMs,
-        String tokenType
+        String tokenType,
+        String refreshToken,
+        long refreshExpiresAtEpochMs
 ) {
-    public AuthResponse(String token, long expiresAtEpochMs) {
-        this(token, expiresAtEpochMs, "Bearer");
+    public AuthResponse(String token, long expiresAtEpochMs, String refreshToken, long refreshExpiresAtEpochMs) {
+        this(token, expiresAtEpochMs, "Bearer", refreshToken, refreshExpiresAtEpochMs);
     }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/RefreshRequest.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/RefreshRequest.java
@@ -1,0 +1,5 @@
+package morning.com.services.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(@NotBlank String refreshToken) {}

--- a/auth-service/src/main/java/morning/com/services/auth/dto/RegisterRequest.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/RegisterRequest.java
@@ -1,0 +1,9 @@
+package morning.com.services.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(
+        @NotBlank String username,
+        @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package morning.com.services.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "refresh_tokens", indexes = {
+        @Index(name = "ix_refresh_tokens_user_id", columnList = "user_id"),
+        @Index(name = "ux_refresh_tokens_token", columnList = "token", unique = true)
+})
+public class RefreshToken {
+    @Id
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+}

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -7,9 +7,11 @@ import java.time.Instant;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "users", indexes = {
-        @Index(name = "ux_users_username", columnList = "username", unique = true)
+        @Index(name = "ux_users_username", columnList = "username", unique = true),
+        @Index(name = "ux_users_email", columnList = "email", unique = true)
 })
 public class User {
     @Id
@@ -18,13 +20,47 @@ public class User {
     @Column(nullable = false, unique = true)
     private String username;
 
+    @Column(nullable = false, unique = true)
+    private String email;
+
     @Column(nullable = false)
     private String passwordHash;
 
-    @Setter
+    @Builder.Default
     @Column(nullable = false)
-    private int failedAttempts;
+    private boolean enabled = true;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private String role = "USER";
+
+    @Setter
+    @Builder.Default
+    @Column(nullable = false)
+    private int failedAttempts = 0;
 
     @Setter
     private Instant lockUntil;
+
+    @Setter
+    private Instant lastLoginAt;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Setter
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package morning.com.services.auth.repository;
+
+import morning.com.services.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/UserRepository.java
@@ -7,5 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
 }

--- a/auth-service/src/main/java/morning/com/services/auth/service/RefreshTokenService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/RefreshTokenService.java
@@ -1,0 +1,46 @@
+package morning.com.services.auth.service;
+
+import jakarta.transaction.Transactional;
+import morning.com.services.auth.entity.RefreshToken;
+import morning.com.services.auth.entity.User;
+import morning.com.services.auth.repository.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository repository;
+    private final Duration ttl;
+
+    public RefreshTokenService(RefreshTokenRepository repository,
+                               @Value("${security.refresh-token.ttl:PT7D}") Duration ttl) {
+        this.repository = repository;
+        this.ttl = ttl;
+    }
+
+    @Transactional
+    public RefreshToken create(User user) {
+        var token = RefreshToken.builder()
+                .id(UUID.randomUUID().toString())
+                .user(user)
+                .token(UUID.randomUUID().toString())
+                .expiresAt(Instant.now().plus(ttl))
+                .build();
+        return repository.save(token);
+    }
+
+    @Transactional
+    public Optional<RefreshToken> refresh(String token) {
+        return repository.findByToken(token)
+                .filter(rt -> rt.getExpiresAt().isAfter(Instant.now()))
+                .map(rt -> {
+                    repository.delete(rt);
+                    return create(rt.getUser());
+                });
+    }
+}

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -32,13 +32,19 @@ public class UserService {
     }
 
     @Transactional
-    public void register(String username, String password) {
-        if (repository.existsByUsername(username)) {
+    public void register(String username, String email, String password) {
+        if (repository.existsByUsername(username) || repository.existsByEmail(email)) {
             throw new IllegalArgumentException(MessageKeys.USERNAME_EXISTS);
         }
         var id = UUID.randomUUID().toString();
         var hash = encoder.encode(password);
-        repository.save(new User(id, username, hash, 0, null));
+        var user = User.builder()
+                .id(id)
+                .username(username)
+                .email(email)
+                .passwordHash(hash)
+                .build();
+        repository.save(user);
     }
 
     public boolean authenticate(String username, String password) {
@@ -52,6 +58,7 @@ public class UserService {
                     if (matches) {
                         u.setFailedAttempts(0);
                         u.setLockUntil(null);
+                        u.setLastLoginAt(now);
                         repository.save(u);
                         return true;
                     }

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -1,11 +1,12 @@
 package morning.com.services.auth.controller;
 
 import morning.com.services.auth.dto.ApiResponse;
-import morning.com.services.auth.dto.AuthRequest;
-import morning.com.services.auth.dto.AuthResponse;
-import morning.com.services.auth.dto.MessageKeys;
+import morning.com.services.auth.dto.*;
 import morning.com.services.auth.exception.AccountLockedException;
+import morning.com.services.auth.entity.RefreshToken;
+import morning.com.services.auth.entity.User;
 import morning.com.services.auth.service.JwtService;
+import morning.com.services.auth.service.RefreshTokenService;
 import morning.com.services.auth.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +16,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 
 import static morning.com.services.auth.dto.ApiResponse.Status.ERROR;
 import static morning.com.services.auth.dto.ApiResponse.Status.SUCCESS;
@@ -31,12 +34,15 @@ class AuthControllerTest {
     @Mock
     private JwtService jwtService;
 
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     @InjectMocks
     private AuthController authController;
 
     @Test
     void registerSuccess() {
-        AuthRequest request = new AuthRequest("user", "password");
+        RegisterRequest request = new RegisterRequest("user", "user@example.com", "password");
 
         ResponseEntity<ApiResponse<Void>> response = authController.register(request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -45,14 +51,14 @@ class AuthControllerTest {
         assertNotNull(body);
         assertEquals(SUCCESS, body.status());
         assertEquals(MessageKeys.USER_REGISTERED, body.messageKey());
-        verify(userService).register("user", "password");
+        verify(userService).register("user", "user@example.com", "password");
     }
 
     @Test
     void registerUsernameExists() {
-        AuthRequest request = new AuthRequest("user", "password");
+        RegisterRequest request = new RegisterRequest("user", "user@example.com", "password");
         doThrow(new IllegalArgumentException(MessageKeys.USERNAME_EXISTS))
-                .when(userService).register("user", "password");
+                .when(userService).register("user", "user@example.com", "password");
 
         ResponseEntity<ApiResponse<Void>> response = authController.register(request);
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
@@ -73,6 +79,13 @@ class AuthControllerTest {
         long exp = System.currentTimeMillis() + 3_600_000L; // +1h
         when(jwtService.getExpiration("token123")).thenReturn(new Date(exp));
 
+        User user = User.builder().id("1").username("user").email("user@example.com").passwordHash("hash").build();
+        when(userService.findByUsername("user")).thenReturn(Optional.of(user));
+
+        Instant rExp = Instant.now().plusSeconds(7200);
+        RefreshToken rt = RefreshToken.builder().id("r1").user(user).token("refresh123").expiresAt(rExp).build();
+        when(refreshTokenService.create(user)).thenReturn(rt);
+
         ResponseEntity<ApiResponse<AuthResponse>> response = authController.login(request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
@@ -84,6 +97,8 @@ class AuthControllerTest {
         assertEquals("token123", body.data().token());
         assertEquals(exp, body.data().expiresAtEpochMs());
         assertEquals("Bearer", body.data().tokenType());
+        assertEquals("refresh123", body.data().refreshToken());
+        assertEquals(rExp.toEpochMilli(), body.data().refreshExpiresAtEpochMs());
     }
 
     @Test
@@ -107,6 +122,39 @@ class AuthControllerTest {
         when(userService.authenticate("user", "password")).thenThrow(new AccountLockedException());
 
         assertThrows(AccountLockedException.class, () -> authController.login(request));
+    }
+
+    @Test
+    void refreshSuccess() {
+        RefreshRequest request = new RefreshRequest("refresh123");
+        User user = User.builder().id("1").username("user").email("user@example.com").passwordHash("hash").build();
+        Instant rExp = Instant.now().plusSeconds(7200);
+        RefreshToken newRt = RefreshToken.builder().id("r2").user(user).token("refresh456").expiresAt(rExp).build();
+
+        when(refreshTokenService.refresh("refresh123")).thenReturn(Optional.of(newRt));
+        when(jwtService.generateToken("user")).thenReturn("token456");
+        long exp = System.currentTimeMillis() + 3_600_000L;
+        when(jwtService.getExpiration("token456")).thenReturn(new Date(exp));
+
+        ResponseEntity<ApiResponse<AuthResponse>> response = authController.refresh(request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        ApiResponse<AuthResponse> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(SUCCESS, body.status());
+        assertEquals("token456", body.data().token());
+        assertEquals("refresh456", body.data().refreshToken());
+    }
+
+    @Test
+    void refreshInvalidToken() {
+        RefreshRequest request = new RefreshRequest("bad");
+        when(refreshTokenService.refresh("bad")).thenReturn(Optional.empty());
+
+        ResponseEntity<ApiResponse<AuthResponse>> response = authController.refresh(request);
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        ApiResponse<AuthResponse> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(ERROR, body.status());
     }
 }
 


### PR DESCRIPTION
## Summary
- expand `User` with email, role, status, timestamps, and indexing
- add refresh token entity/service and refresh endpoint for JWT rotation
- update login/register flow and tests for refresh tokens

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6895ccee3d34832d8c288a0ef12aab65