### PR TITLE
feat(auth): add logout endpoint

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -2,6 +2,10 @@
 
 The auth service returns message keys instead of translated text in API responses. Consumers should translate these keys on the client side using their preferred i18n library.
 
+## Endpoints
+
+- `POST /auth/logout` – revokes the provided refresh token.
+
 ## Response format
 
 ```json

--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -89,4 +89,14 @@ public class AuthController {
             return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
         }
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@Valid @RequestBody RefreshRequest request) {
+        try {
+            refreshTokenService.revoke(request.refreshToken());
+            return ApiResponse.success(MessageKeys.SUCCESS);
+        } catch (IllegalArgumentException ex) {
+            return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add service method to revoke refresh tokens
- expose `/auth/logout` endpoint to invalidate a refresh token
- document the new logout endpoint

## Testing
- `mvn -pl auth-service test` *(fails: Non-resolvable parent POM for morning.com.services:spring-boot-subscription-platform)*

------
https://chatgpt.com/codex/tasks/task_e_68971fb39b80832dba92cd65328b3740