### PR TITLE
feat(auth): add password change endpoint

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -99,4 +99,29 @@ public class AuthController {
             return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
         }
     }
+
+    @PostMapping("/change-password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @RequestHeader(name = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            @Valid @RequestBody PasswordChangeRequest request) {
+        if (authorization == null) {
+            return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
+        }
+        String auth = authorization.trim();
+        if (!auth.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
+        }
+        String token = auth.substring(7).trim();
+        String username;
+        try {
+            username = jwtService.getUsername(token);
+        } catch (JwtException e) {
+            return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
+        }
+        boolean changed = userService.changePassword(username, request.currentPassword(), request.newPassword());
+        if (changed) {
+            return ApiResponse.success(MessageKeys.PASSWORD_CHANGED);
+        }
+        return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS);
+    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/dto/MessageKeys.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/MessageKeys.java
@@ -10,5 +10,6 @@ public final class MessageKeys {
     public static final String INVALID_CREDENTIALS = "auth.invalid.credentials";
     public static final String ACCOUNT_LOCKED = "auth.account.locked";
     public static final String VALIDATION_ERROR = "auth.validation.error";
+    public static final String PASSWORD_CHANGED = "auth.password.changed";
 }
 

--- a/auth-service/src/main/java/morning/com/services/auth/dto/PasswordChangeRequest.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/PasswordChangeRequest.java
@@ -1,0 +1,9 @@
+package morning.com.services.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordChangeRequest(
+        @NotBlank String currentPassword,
+        @NotBlank String newPassword
+) {}
+

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -30,6 +30,7 @@ public class User {
     @Column(length = 190, unique = true)
     private String email;
 
+    @Setter
     @Column(nullable = false)
     private String passwordHash;
 

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -91,4 +91,19 @@ public class UserService {
                 .map(User::getUsername)
                 .orElseThrow();
     }
+
+    @Transactional
+    public boolean changePassword(String username, String currentPassword, String newPassword) {
+        String normalized = username.toLowerCase();
+        return repository.findByUsername(normalized)
+                .map(user -> {
+                    if (!encoder.matches(currentPassword, user.getPasswordHash())) {
+                        return false;
+                    }
+                    user.setPasswordHash(encoder.encode(newPassword));
+                    user.setLastPasswordChangeAt(Instant.now());
+                    repository.save(user);
+                    return true;
+                }).orElse(false);
+    }
 }

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -168,5 +168,33 @@ class AuthControllerTest {
         assertNotNull(body);
         assertEquals(ERROR, body.status());
     }
+
+    @Test
+    void changePasswordSuccess() {
+        PasswordChangeRequest request = new PasswordChangeRequest("old", "new");
+        when(jwtService.getUsername("token")).thenReturn("user");
+        when(userService.changePassword("user", "old", "new")).thenReturn(true);
+
+        ResponseEntity<ApiResponse<Void>> response = authController.changePassword("Bearer token", request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        ApiResponse<Void> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(SUCCESS, body.status());
+        assertEquals(MessageKeys.PASSWORD_CHANGED, body.messageKey());
+    }
+
+    @Test
+    void changePasswordInvalidCredentials() {
+        PasswordChangeRequest request = new PasswordChangeRequest("old", "new");
+        when(jwtService.getUsername("token")).thenReturn("user");
+        when(userService.changePassword("user", "old", "new")).thenReturn(false);
+
+        ResponseEntity<ApiResponse<Void>> response = authController.changePassword("Bearer token", request);
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        ApiResponse<Void> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(ERROR, body.status());
+        assertEquals(MessageKeys.INVALID_CREDENTIALS, body.messageKey());
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow users to change their password with JWT auth
- add PasswordChangeRequest DTO and associated constant
- update tests for password change flow

## Testing
- `mvn -q -pl auth-service test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689725fa1ce0832d9922f9f8158e4f23