### PR TITLE
Add user-service and database to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,31 @@ services:
       - zipkin
     environment:
       SPRING_PROFILES_ACTIVE: docker
+
+  user-db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: userdb
+    ports:
+      - "3307:3306"
+
+  user-service:
+    image: sbsp/user-service:1.0-SNAPSHOT
+    ports:
+      - "8080"
+    depends_on:
+      discovery-service:
+        condition: service_healthy
+      user-db:
+        condition: service_started
+    links:
+      - config-service
+      - discovery-service
+      - zipkin
+      - user-db
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
   auth-db:
     image: mysql:8.0
     environment:
@@ -114,4 +139,5 @@ services:
       - employee-service
       - department-service
       - organization-service
+      - user-service
       - zipkin


### PR DESCRIPTION
## Summary
- include user-db MySQL container for user-service
- link user-service to user-db for persistence

## Testing
- `docker compose config` *(fails: command not found: docker)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.35 8080])* 
- `docker-compose config` *(fails: command not found: docker-compose)*
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68995b65808c832d84ad7691ec8ed180