### PR TITLE
Add user-service database configuration

### DIFF
--- a/config-service/src/main/resources/config/user-service-docker.yml
+++ b/config-service/src/main/resources/config/user-service-docker.yml
@@ -19,6 +19,19 @@ spring:
   output:
     ansi:
       enabled: always
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://user-db:3306/userdb}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:password}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/user-service.yml
+++ b/config-service/src/main/resources/config/user-service.yml
@@ -25,6 +25,19 @@ spring:
   output:
     ansi:
       enabled: always
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3307/userdb}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:password}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 management:
   tracing:


### PR DESCRIPTION
## Summary
- configure user-service data source, JPA, and Flyway settings in config-service for local and docker profiles

## Testing
- `mvn -q -pl config-service -am test` *(fails: Non-resolvable parent POM for org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68995e9a60d4832d9058d55b1f6964c0