### PR TITLE
Add user-service route to gateway configuration

### DIFF
--- a/config-service/src/main/resources/config/gateway-service-docker.yml
+++ b/config-service/src/main/resources/config/gateway-service-docker.yml
@@ -50,6 +50,12 @@ spring:
         - Path=/organization/**
         filters:
         - RewritePath=/organization/(?<path>.*), /$\{path}
+      - id: user-service
+        uri: lb://user-service
+        predicates:
+        - Path=/user/**
+        filters:
+        - RewritePath=/user/(?<path>.*), /$\{path}
       - id: openapi
         uri: http://localhost:${server.port}
         predicates:
@@ -68,6 +74,8 @@ springdoc:
         url: /v3/api-docs/department
       - name: organization
         url: /v3/api-docs/organization
+      - name: user
+        url: /v3/api-docs/user
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/gateway-service.yml
+++ b/config-service/src/main/resources/config/gateway-service.yml
@@ -51,6 +51,12 @@ spring:
         - Path=/organization/**
         filters:
         - RewritePath=/organization/(?<path>.*), /$\{path}
+      - id: user-service
+        uri: lb://user-service
+        predicates:
+        - Path=/user/**
+        filters:
+        - RewritePath=/user/(?<path>.*), /$\{path}
       - id: openapi
         uri: http://localhost:${server.port}
         predicates:


### PR DESCRIPTION
## Summary
- route user-service through gateway
- expose user service OpenAPI docs via docker gateway config

## Testing
- `mvn -q -pl config-service test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689961d90444832da187b7b09cfbafcc