### PR TITLE
refactor: unify user ids and drop roles

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -6,8 +6,6 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
-import java.util.HashSet;
-import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -66,20 +64,10 @@ public class User {
     @Column(length = 128)
     private String totpSecret;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
-    @Column(name = "role")
-    @Enumerated(EnumType.STRING)
-    private Set<Role> roles = new HashSet<>();
-
     @Setter
     @Column(nullable = false)
     private int failedAttempts;
 
     @Setter
     private Instant lockUntil;
-
-    public enum Role {
-        USER, ADMIN
-    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -42,7 +41,7 @@ public class UserService {
         var hash = encoder.encode(password);
         var user = new User(id, normalized, null, hash, false, true,
                 null, null, null, null, null, null, false, null,
-                Set.of(User.Role.USER), 0, null);
+                0, null);
         repository.save(user);
     }
 

--- a/auth-service/src/main/resources/db/migration/V1__init_auth_schema.sql
+++ b/auth-service/src/main/resources/db/migration/V1__init_auth_schema.sql
@@ -29,16 +29,6 @@ CREATE INDEX ix_users_lock_until ON users (lock_until);
 CREATE INDEX ix_users_enabled ON users (enabled);
 CREATE INDEX ix_users_last_login ON users (last_login_at);
 
--- USER ROLES (simple role list, many-to-one)
-CREATE TABLE user_roles
-(
-    user_id VARCHAR(36)  NOT NULL,
-    role    VARCHAR(255) NOT NULL,
-    PRIMARY KEY (user_id, role),
-    CONSTRAINT fk_user_roles_user
-        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 -- REFRESH TOKENS (hashed; revoke via revoked_at)
 CREATE TABLE refresh_tokens
 (

--- a/user-service/src/main/java/morning/com/services/user/controller/UserController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public UserProfile findById(@PathVariable("id") Long id) {
+    public UserProfile findById(@PathVariable("id") String id) {
         LOGGER.info("User find: id={}", id);
         return repository.findById(id);
     }

--- a/user-service/src/main/java/morning/com/services/user/model/UserProfile.java
+++ b/user-service/src/main/java/morning/com/services/user/model/UserProfile.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  */
 public class UserProfile {
 
-    private Long id;
+    private String id;
     private String username;
     private String email;
     private String phone;
@@ -27,11 +27,11 @@ public class UserProfile {
         this.tenantId = tenantId;
     }
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/user-service/src/main/java/morning/com/services/user/repository/UserRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/UserRepository.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import morning.com.services.user.model.UserPage;
@@ -18,15 +18,14 @@ import org.springframework.stereotype.Repository;
 public class UserRepository {
 
     private final List<UserProfile> users = new ArrayList<>();
-    private final AtomicLong sequence = new AtomicLong(0);
 
     public UserProfile add(UserProfile user) {
-        user.setId(sequence.incrementAndGet());
+        user.setId(UUID.randomUUID().toString());
         users.add(user);
         return user;
     }
 
-    public UserProfile findById(Long id) {
+    public UserProfile findById(String id) {
         return users.stream()
                 .filter(u -> u.getId().equals(id))
                 .findFirst()

--- a/user-service/src/main/resources/db/migration/V1__init_user_profile_schema.sql
+++ b/user-service/src/main/resources/db/migration/V1__init_user_profile_schema.sql
@@ -1,6 +1,6 @@
 -- USER PROFILES
 CREATE TABLE users_profile (
-    id BIGINT NOT NULL AUTO_INCREMENT,
+    id VARCHAR(36) NOT NULL,
     username VARCHAR(100) NOT NULL,
     email VARCHAR(190) NULL,
     phone VARCHAR(32) NULL,


### PR DESCRIPTION
## Summary
- remove unused user_roles mapping from auth-service
- standardize user IDs as strings across services

## Testing
- `mvn -q -pl auth-service,user-service test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ac3c8b550832d9acc23b531f2a1b5