### PR TITLE
feat(user-service): add user profile persistence

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -1,0 +1,28 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.service.UserProfileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserProfileController {
+    private final UserProfileService service;
+
+    public UserProfileController(UserProfileService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public UserProfile create(@RequestBody UserProfile profile) {
+        return service.add(profile);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserProfile> get(@PathVariable String id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
@@ -1,0 +1,53 @@
+package morning.com.services.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "users_profile", indexes = {
+        @Index(name = "ux_users_profile_username", columnList = "username", unique = true),
+        @Index(name = "ux_users_profile_email", columnList = "email", unique = true),
+        @Index(name = "ix_users_profile_tenant_id", columnList = "tenant_id"),
+        @Index(name = "ix_users_profile_status", columnList = "status"),
+        @Index(name = "ix_users_profile_phone", columnList = "phone")
+})
+public class UserProfile {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String username;
+
+    @Column(length = 190, unique = true)
+    private String email;
+
+    @Column(length = 32)
+    private String phone;
+
+    @Column(nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "tenant_id", nullable = false, length = 36)
+    private String tenantId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/user-service/src/main/java/morning/com/services/user/repository/UserProfileRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/UserProfileRepository.java
@@ -1,0 +1,12 @@
+package morning.com.services.user.repository;
+
+import morning.com.services.user.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, String> {
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+    Optional<UserProfile> findByUsername(String username);
+}

--- a/user-service/src/main/java/morning/com/services/user/service/UserProfileService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/UserProfileService.java
@@ -1,0 +1,26 @@
+package morning.com.services.user.service;
+
+import jakarta.transaction.Transactional;
+import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.repository.UserProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserProfileService {
+    private final UserProfileRepository repository;
+
+    public UserProfileService(UserProfileRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public UserProfile add(UserProfile profile) {
+        return repository.save(profile);
+    }
+
+    public Optional<UserProfile> findById(String id) {
+        return repository.findById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA entity for user profiles
- expose basic CRUD endpoints for user profiles

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ae7493484832dbf49e1502f58bda9