### PR TITLE
Use binary UUIDs for entity identifiers

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -43,7 +44,7 @@ public class AuthController {
             String username = request.username().toLowerCase();
             String token = jwtService.generateToken(username);
             long exp = System.currentTimeMillis() + jwtService.ttlMillis();
-            String userId = userService.findUserIdByUsername(username);
+            UUID userId = userService.findUserIdByUsername(username);
             var issued = refreshTokenService.issue(userId, http.getRemoteAddr(), http.getHeader(HttpHeaders.USER_AGENT));
             return ApiResponse.success(MessageKeys.SUCCESS,
                     new AuthResponse(token, exp, issued.rawToken()));
@@ -72,7 +73,7 @@ public class AuthController {
         }
 
         return userService.findByUsername(username)
-                .map(u -> ApiResponse.success(MessageKeys.SUCCESS, new UserInfo(u.getId().toString(), u.getUsername())))
+                .map(u -> ApiResponse.success(MessageKeys.SUCCESS, new UserInfo(u.getId(), u.getUsername())))
                 .orElseGet(() -> ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.INVALID_CREDENTIALS));
     }
 

--- a/auth-service/src/main/java/morning/com/services/auth/dto/UserInfo.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/UserInfo.java
@@ -1,3 +1,5 @@
 package morning.com.services.auth.dto;
 
-public record UserInfo(String id, String username) {}
+import java.util.UUID;
+
+public record UserInfo(UUID id, String username) {}

--- a/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/RefreshToken.java
@@ -3,8 +3,12 @@ package morning.com.services.auth.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Setter
 @Getter
@@ -15,11 +19,15 @@ import java.time.Instant;
 @Table(name = "refresh_tokens")
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID id;
 
-    @Column(length = 36, nullable = false)
-    private String userId;
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false)
+    private UUID userId;
 
     @Column(length = 128, nullable = false)
     private String tokenHash;

--- a/auth-service/src/main/java/morning/com/services/auth/entity/User.java
+++ b/auth-service/src/main/java/morning/com/services/auth/entity/User.java
@@ -19,9 +19,9 @@ import java.util.UUID;
 public class User {
     @Id
     @GeneratedValue
-    @UuidGenerator
-    @JdbcTypeCode(SqlTypes.CHAR)
-    @Column(columnDefinition = "CHAR(36)", nullable = false, updatable = false)
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     private UUID id;
 
     @Setter

--- a/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
+++ b/auth-service/src/main/java/morning/com/services/auth/repository/RefreshTokenRepository.java
@@ -3,5 +3,7 @@ package morning.com.services.auth.repository;
 import morning.com.services.auth.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 }

--- a/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
+++ b/auth-service/src/main/java/morning/com/services/auth/service/UserService.java
@@ -84,14 +84,14 @@ public class UserService {
         return repository.findByUsername(username.toLowerCase());
     }
 
-    public String findUserIdByUsername(String username) {
+    public UUID findUserIdByUsername(String username) {
         return repository.findByUsername(username.toLowerCase())
-                .map(u -> u.getId().toString())
+                .map(User::getId)
                 .orElseThrow();
     }
 
-    public String findUsernameById(String userId) {
-        return repository.findById(UUID.fromString(userId))
+    public String findUsernameById(UUID userId) {
+        return repository.findById(userId)
                 .map(User::getUsername)
                 .orElseThrow();
     }

--- a/auth-service/src/main/resources/db/migration/V1__init_auth_schema.sql
+++ b/auth-service/src/main/resources/db/migration/V1__init_auth_schema.sql
@@ -1,7 +1,7 @@
 -- USERS
 CREATE TABLE users
 (
-    id                      CHAR(36) NOT NULL,
+    id                      BINARY(16) NOT NULL,
     username                VARCHAR(100) NOT NULL,
     password_hash           VARCHAR(255) NOT NULL,
     failed_attempts         INT UNSIGNED NOT NULL DEFAULT 0,
@@ -34,8 +34,8 @@ CREATE INDEX ix_users_last_login ON users (last_login_at);
 -- REFRESH TOKENS (hashed; revoke via revoked_at)
 CREATE TABLE refresh_tokens
 (
-    id      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    user_id    CHAR(36) NOT NULL,
+    id      BINARY(16) NOT NULL,
+    user_id    BINARY(16) NOT NULL,
     token_hash VARCHAR(128) NOT NULL,
     expires_at TIMESTAMP(6) NOT NULL,
     revoked_at TIMESTAMP(6) NULL,

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -5,6 +5,8 @@ import morning.com.services.user.service.UserProfileService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/user")
 public class UserProfileController {
@@ -20,7 +22,7 @@ public class UserProfileController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<UserProfile> get(@PathVariable String id) {
+    public ResponseEntity<UserProfile> get(@PathVariable UUID id) {
         return service.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
@@ -22,8 +22,8 @@ import java.util.UUID;
 public class UserProfile {
 
     @Id
-    @JdbcTypeCode(SqlTypes.CHAR)
-    @Column( columnDefinition = "CHAR(36)", nullable = false, updatable = false)
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     private UUID userId;
 
     @Column(nullable = false, unique = true, length = 100)

--- a/user-service/src/main/java/morning/com/services/user/repository/UserProfileRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/UserProfileRepository.java
@@ -4,8 +4,9 @@ import morning.com.services.user.entity.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UserProfileRepository extends JpaRepository<UserProfile, String> {
+public interface UserProfileRepository extends JpaRepository<UserProfile, UUID> {
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     Optional<UserProfile> findByUsername(String username);

--- a/user-service/src/main/java/morning/com/services/user/service/UserProfileService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/UserProfileService.java
@@ -6,6 +6,7 @@ import morning.com.services.user.repository.UserProfileRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class UserProfileService {
@@ -20,7 +21,7 @@ public class UserProfileService {
         return repository.save(profile);
     }
 
-    public Optional<UserProfile> findById(String id) {
+    public Optional<UserProfile> findById(UUID id) {
         return repository.findById(id);
     }
 }

--- a/user-service/src/main/resources/db/migration/V1__init_user_profile_schema.sql
+++ b/user-service/src/main/resources/db/migration/V1__init_user_profile_schema.sql
@@ -1,7 +1,7 @@
 -- USER PROFILES
 CREATE TABLE users_profile
 (
-    user_id    CHAR(36) NOT NULL,
+    user_id    BINARY(16) NOT NULL,
     username   VARCHAR(100) NOT NULL,
     email      VARCHAR(190) NULL,
     phone      VARCHAR(32) NULL,

--- a/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
@@ -39,23 +40,25 @@ class UserProfileControllerTest {
     @Test
     void getReturnsProfileWhenFound() {
         UserProfile saved = new UserProfile(null, null, null, null, true, null, null);
-        when(service.findById("id1")).thenReturn(Optional.of(saved));
+        UUID id = UUID.randomUUID();
+        when(service.findById(id)).thenReturn(Optional.of(saved));
 
-        ResponseEntity<UserProfile> response = controller.get("id1");
+        ResponseEntity<UserProfile> response = controller.get(id);
 
         assertEquals(200, response.getStatusCodeValue());
         assertSame(saved, response.getBody());
-        verify(service).findById("id1");
+        verify(service).findById(id);
     }
 
     @Test
     void getReturnsNotFoundWhenMissing() {
-        when(service.findById("missing")).thenReturn(Optional.empty());
+        UUID missing = UUID.randomUUID();
+        when(service.findById(missing)).thenReturn(Optional.empty());
 
-        ResponseEntity<UserProfile> response = controller.get("missing");
+        ResponseEntity<UserProfile> response = controller.get(missing);
 
         assertEquals(404, response.getStatusCodeValue());
         assertNull(response.getBody());
-        verify(service).findById("missing");
+        verify(service).findById(missing);
     }
 }


### PR DESCRIPTION
## Summary
- store `User`, `RefreshToken`, and `UserProfile` ids as UUIDv7 in `BINARY(16)` columns
- update services and controllers to work with `UUID` identifiers
- adjust Flyway migrations and unit tests for binary UUIDs

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c0b2f6118832db33c60b8978c5d77