### PR TITLE
feat(user-service): unify response model with auth-service

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -1,7 +1,10 @@
 package morning.com.services.user.controller;
 
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.entity.UserProfile;
 import morning.com.services.user.service.UserProfileService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,14 +20,19 @@ public class UserProfileController {
     }
 
     @PostMapping
-    public UserProfile create(@RequestBody UserProfile profile) {
-        return service.add(profile);
+    public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfile profile) {
+        UserProfile saved = service.add(profile);
+        return ApiResponse.created(
+                MessageKeys.PROFILE_CREATED,
+                saved,
+                "/user/" + saved.getUserId()
+        );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<UserProfile> get(@PathVariable UUID id) {
+    public ResponseEntity<ApiResponse<UserProfile>> get(@PathVariable UUID id) {
         return service.findById(id)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .map(profile -> ApiResponse.success(MessageKeys.SUCCESS, profile))
+                .orElseGet(() -> ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PROFILE_NOT_FOUND));
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/dto/ApiResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/ApiResponse.java
@@ -1,0 +1,45 @@
+package morning.com.services.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Standard API wrapper for user-service responses.
+ * Mirrors the structure used by auth-service to ensure
+ * consistent payloads across services.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(Status status, String messageKey, T data) {
+
+    public enum Status {
+        SUCCESS("success"), ERROR("error");
+        private final String json;
+        Status(String json) { this.json = json; }
+        @JsonValue public String json() { return json; }
+    }
+
+    // ---- Factory helpers producing ResponseEntity<ApiResponse<T>> ----
+    public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey, T data) {
+        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey) {
+        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, null));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> created(String messageKey, T data, String location) {
+        return ResponseEntity.created(java.net.URI.create(location))
+                .body(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey) {
+        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, null));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey, T data) {
+        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, data));
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
@@ -1,0 +1,14 @@
+package morning.com.services.user.dto;
+
+/**
+ * Message key constants for the user-service domain.
+ */
+public final class MessageKeys {
+    private MessageKeys() {}
+
+    public static final String SUCCESS = "user.success";
+    public static final String PROFILE_CREATED = "user.profile.created";
+    public static final String PROFILE_NOT_FOUND = "user.profile.not_found";
+    public static final String VALIDATION_ERROR = "user.validation.error";
+}
+

--- a/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package morning.com.services.user.exception;
+
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    }
+}
+

--- a/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
@@ -1,5 +1,7 @@
 package morning.com.services.user.controller;
 
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.entity.UserProfile;
 import morning.com.services.user.service.UserProfileService;
 import org.junit.jupiter.api.Test;
@@ -31,9 +33,14 @@ class UserProfileControllerTest {
         UserProfile saved = new UserProfile(null, null, null, null, true, null, null);
         when(service.add(input)).thenReturn(saved);
 
-        UserProfile result = controller.create(input);
+        ResponseEntity<ApiResponse<UserProfile>> result = controller.create(input);
 
-        assertSame(saved, result);
+        assertEquals(201, result.getStatusCodeValue());
+        ApiResponse<UserProfile> body = result.getBody();
+        assertNotNull(body);
+        assertEquals(ApiResponse.Status.SUCCESS, body.status());
+        assertEquals(MessageKeys.PROFILE_CREATED, body.messageKey());
+        assertSame(saved, body.data());
         verify(service).add(input);
     }
 
@@ -43,10 +50,14 @@ class UserProfileControllerTest {
         UUID id = UUID.randomUUID();
         when(service.findById(id)).thenReturn(Optional.of(saved));
 
-        ResponseEntity<UserProfile> response = controller.get(id);
+        ResponseEntity<ApiResponse<UserProfile>> response = controller.get(id);
 
         assertEquals(200, response.getStatusCodeValue());
-        assertSame(saved, response.getBody());
+        ApiResponse<UserProfile> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(ApiResponse.Status.SUCCESS, body.status());
+        assertEquals(MessageKeys.SUCCESS, body.messageKey());
+        assertSame(saved, body.data());
         verify(service).findById(id);
     }
 
@@ -55,10 +66,14 @@ class UserProfileControllerTest {
         UUID missing = UUID.randomUUID();
         when(service.findById(missing)).thenReturn(Optional.empty());
 
-        ResponseEntity<UserProfile> response = controller.get(missing);
+        ResponseEntity<ApiResponse<UserProfile>> response = controller.get(missing);
 
         assertEquals(404, response.getStatusCodeValue());
-        assertNull(response.getBody());
+        ApiResponse<UserProfile> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(ApiResponse.Status.ERROR, body.status());
+        assertEquals(MessageKeys.PROFILE_NOT_FOUND, body.messageKey());
+        assertNull(body.data());
         verify(service).findById(missing);
     }
 }


### PR DESCRIPTION
## Summary
- add ApiResponse and MessageKeys to user-service
- wrap user profile endpoints with ApiResponse
- add global exception handler and update tests

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c180e73c4832d828d14ea5aef2d98