### PR TITLE
feat(user-service): add roles and permissions

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/permission")
+@RequestMapping("/user/permission")
 public class PermissionController {
     private final PermissionService service;
 

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -1,0 +1,31 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.entity.Permission;
+import morning.com.services.user.service.PermissionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/permission")
+public class PermissionController {
+    private final PermissionService service;
+
+    public PermissionController(PermissionService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Permission>> create(@RequestBody Permission permission) {
+        Permission saved = service.add(permission);
+        return ApiResponse.created(
+                MessageKeys.PERMISSION_CREATED,
+                saved,
+                "/permission/" + saved.getPermissionId()
+        );
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/role")
+@RequestMapping("/user/role")
 public class RoleController {
     private final RoleService service;
     private final PermissionService permissionService;

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -1,0 +1,46 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.entity.Role;
+import morning.com.services.user.service.PermissionService;
+import morning.com.services.user.service.RoleService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/role")
+public class RoleController {
+    private final RoleService service;
+    private final PermissionService permissionService;
+
+    public RoleController(RoleService service, PermissionService permissionService) {
+        this.service = service;
+        this.permissionService = permissionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Role>> create(@RequestBody Role role) {
+        Role saved = service.add(role);
+        return ApiResponse.created(
+                MessageKeys.ROLE_CREATED,
+                saved,
+                "/role/" + saved.getRoleId()
+        );
+    }
+
+    @PostMapping("/{roleId}/permissions/{permissionId}")
+    public ResponseEntity<ApiResponse<Role>> addPermission(@PathVariable UUID roleId, @PathVariable UUID permissionId) {
+        if (service.findById(roleId).isEmpty()) {
+            return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.ROLE_NOT_FOUND);
+        }
+        if (permissionService.findById(permissionId).isEmpty()) {
+            return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PERMISSION_NOT_FOUND);
+        }
+        Role updated = service.addPermission(roleId, permissionId);
+        return ApiResponse.success(MessageKeys.SUCCESS, updated);
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -3,6 +3,7 @@ package morning.com.services.user.controller;
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.service.RoleService;
 import morning.com.services.user.service.UserProfileService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +15,11 @@ import java.util.UUID;
 @RequestMapping("/user")
 public class UserProfileController {
     private final UserProfileService service;
+    private final RoleService roleService;
 
-    public UserProfileController(UserProfileService service) {
+    public UserProfileController(UserProfileService service, RoleService roleService) {
         this.service = service;
+        this.roleService = roleService;
     }
 
     @PostMapping
@@ -34,5 +37,17 @@ public class UserProfileController {
         return service.findById(id)
                 .map(profile -> ApiResponse.success(MessageKeys.SUCCESS, profile))
                 .orElseGet(() -> ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PROFILE_NOT_FOUND));
+    }
+
+    @PostMapping("/{id}/roles/{roleId}")
+    public ResponseEntity<ApiResponse<UserProfile>> addRole(@PathVariable UUID id, @PathVariable UUID roleId) {
+        if (service.findById(id).isEmpty()) {
+            return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PROFILE_NOT_FOUND);
+        }
+        if (roleService.findById(roleId).isEmpty()) {
+            return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.ROLE_NOT_FOUND);
+        }
+        UserProfile updated = roleService.addRoleToUser(id, roleId);
+        return ApiResponse.success(MessageKeys.SUCCESS, updated);
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
@@ -10,5 +10,9 @@ public final class MessageKeys {
     public static final String PROFILE_CREATED = "user.profile.created";
     public static final String PROFILE_NOT_FOUND = "user.profile.not_found";
     public static final String VALIDATION_ERROR = "user.validation.error";
+    public static final String ROLE_CREATED = "user.role.created";
+    public static final String ROLE_NOT_FOUND = "user.role.not_found";
+    public static final String PERMISSION_CREATED = "user.permission.created";
+    public static final String PERMISSION_NOT_FOUND = "user.permission.not_found";
 }
 

--- a/user-service/src/main/java/morning/com/services/user/entity/Permission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Permission.java
@@ -1,0 +1,28 @@
+package morning.com.services.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "permissions")
+public class Permission {
+
+    @Id
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID permissionId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String name;
+}

--- a/user-service/src/main/java/morning/com/services/user/entity/Role.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Role.java
@@ -1,0 +1,35 @@
+package morning.com.services.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID roleId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String name;
+
+    @ManyToMany
+    @JoinTable(
+            name = "role_permissions",
+            joinColumns = @JoinColumn(name = "role_id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id")
+    )
+    private Set<Permission> permissions = new HashSet<>();
+}

--- a/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/UserProfile.java
@@ -1,9 +1,6 @@
 package morning.com.services.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -11,6 +8,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -45,4 +44,12 @@ public class UserProfile {
     @UpdateTimestamp
     @Column(nullable = false)
     private Instant updatedAt;
+
+    @ManyToMany
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
 }

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -1,0 +1,9 @@
+package morning.com.services.user.repository;
+
+import morning.com.services.user.entity.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PermissionRepository extends JpaRepository<Permission, UUID> {
+}

--- a/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
@@ -1,0 +1,9 @@
+package morning.com.services.user.repository;
+
+import morning.com.services.user.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+}

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -1,0 +1,27 @@
+package morning.com.services.user.service;
+
+import jakarta.transaction.Transactional;
+import morning.com.services.user.entity.Permission;
+import morning.com.services.user.repository.PermissionRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PermissionService {
+    private final PermissionRepository repository;
+
+    public PermissionService(PermissionRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public Permission add(Permission permission) {
+        return repository.save(permission);
+    }
+
+    public Optional<Permission> findById(UUID id) {
+        return repository.findById(id);
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -1,0 +1,53 @@
+package morning.com.services.user.service;
+
+import jakarta.transaction.Transactional;
+import morning.com.services.user.entity.Permission;
+import morning.com.services.user.entity.Role;
+import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.repository.RoleRepository;
+import morning.com.services.user.repository.UserProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RoleService {
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+    private final UserProfileRepository userRepository;
+
+    public RoleService(RoleRepository roleRepository,
+                       PermissionRepository permissionRepository,
+                       UserProfileRepository userRepository) {
+        this.roleRepository = roleRepository;
+        this.permissionRepository = permissionRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public Role add(Role role) {
+        return roleRepository.save(role);
+    }
+
+    public Optional<Role> findById(UUID id) {
+        return roleRepository.findById(id);
+    }
+
+    @Transactional
+    public Role addPermission(UUID roleId, UUID permissionId) {
+        Role role = roleRepository.findById(roleId).orElseThrow();
+        Permission permission = permissionRepository.findById(permissionId).orElseThrow();
+        role.getPermissions().add(permission);
+        return role;
+    }
+
+    @Transactional
+    public UserProfile addRoleToUser(UUID userId, UUID roleId) {
+        UserProfile user = userRepository.findById(userId).orElseThrow();
+        Role role = roleRepository.findById(roleId).orElseThrow();
+        user.getRoles().add(role);
+        return user;
+    }
+}

--- a/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
+++ b/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
@@ -1,0 +1,49 @@
+-- ROLES
+CREATE TABLE roles
+(
+    role_id BINARY(16) NOT NULL,
+    name    VARCHAR(100) NOT NULL,
+
+    CONSTRAINT pk_roles PRIMARY KEY (role_id),
+    CONSTRAINT ux_roles_name UNIQUE (name)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+-- PERMISSIONS
+CREATE TABLE permissions
+(
+    permission_id BINARY(16) NOT NULL,
+    name          VARCHAR(100) NOT NULL,
+
+    CONSTRAINT pk_permissions PRIMARY KEY (permission_id),
+    CONSTRAINT ux_permissions_name UNIQUE (name)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+-- USER ROLES
+CREATE TABLE user_roles
+(
+    user_id BINARY(16) NOT NULL,
+    role_id BINARY(16) NOT NULL,
+
+    CONSTRAINT pk_user_roles PRIMARY KEY (user_id, role_id),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users_profile (user_id),
+    CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles (role_id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+-- ROLE PERMISSIONS
+CREATE TABLE role_permissions
+(
+    role_id       BINARY(16) NOT NULL,
+    permission_id BINARY(16) NOT NULL,
+
+    CONSTRAINT pk_role_permissions PRIMARY KEY (role_id, permission_id),
+    CONSTRAINT fk_role_permissions_role FOREIGN KEY (role_id) REFERENCES roles (role_id),
+    CONSTRAINT fk_role_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions (permission_id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
@@ -3,6 +3,7 @@ package morning.com.services.user.controller;
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.service.RoleService;
 import morning.com.services.user.service.UserProfileService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,13 +25,16 @@ class UserProfileControllerTest {
     @Mock
     UserProfileService service;
 
+    @Mock
+    RoleService roleService;
+
     @InjectMocks
     UserProfileController controller;
 
     @Test
     void createDelegatesToService() {
-        UserProfile input = new UserProfile(null, null, null, null, true, null, null);
-        UserProfile saved = new UserProfile(null, null, null, null, true, null, null);
+        UserProfile input = new UserProfile(null, null, null, null, true, null, null, java.util.Collections.emptySet());
+        UserProfile saved = new UserProfile(null, null, null, null, true, null, null, java.util.Collections.emptySet());
         when(service.add(input)).thenReturn(saved);
 
         ResponseEntity<ApiResponse<UserProfile>> result = controller.create(input);
@@ -46,7 +50,7 @@ class UserProfileControllerTest {
 
     @Test
     void getReturnsProfileWhenFound() {
-        UserProfile saved = new UserProfile(null, null, null, null, true, null, null);
+        UserProfile saved = new UserProfile(null, null, null, null, true, null, null, java.util.Collections.emptySet());
         UUID id = UUID.randomUUID();
         when(service.findById(id)).thenReturn(Optional.of(saved));
 


### PR DESCRIPTION
## Summary
- add Role and Permission entities with JPA mappings
- expose endpoints to manage roles, permissions, and user-role assignments
- expand message keys to cover new role and permission actions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c2bd7b1b8832da067439e2e0e1834