### PR TITLE
feat: generate uuid for roles and permissions

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -25,7 +25,7 @@ public class PermissionController {
         return ApiResponse.created(
                 MessageKeys.PERMISSION_CREATED,
                 saved,
-                "/permission/" + saved.getPermissionId()
+                "/permission/" + saved.getId()
         );
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -28,7 +28,7 @@ public class RoleController {
         return ApiResponse.created(
                 MessageKeys.ROLE_CREATED,
                 saved,
-                "/role/" + saved.getRoleId()
+                "/role/" + saved.getId()
         );
     }
 

--- a/user-service/src/main/java/morning/com/services/user/entity/Permission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Permission.java
@@ -2,10 +2,12 @@ package morning.com.services.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
@@ -19,9 +21,11 @@ import java.util.UUID;
 public class Permission {
 
     @Id
+    @GeneratedValue
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
     @JdbcTypeCode(SqlTypes.BINARY)
     @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
-    private UUID permissionId;
+    private UUID id;
 
     @Column(nullable = false, unique = true, length = 100)
     private String name;

--- a/user-service/src/main/java/morning/com/services/user/entity/Role.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Role.java
@@ -3,6 +3,7 @@ package morning.com.services.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
 
 import java.util.HashSet;
@@ -18,9 +19,11 @@ import java.util.UUID;
 public class Role {
 
     @Id
+    @GeneratedValue
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
     @JdbcTypeCode(SqlTypes.BINARY)
     @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
-    private UUID roleId;
+    private UUID id;
 
     @Column(nullable = false, unique = true, length = 100)
     private String name;
@@ -28,8 +31,8 @@ public class Role {
     @ManyToMany
     @JoinTable(
             name = "role_permissions",
-            joinColumns = @JoinColumn(name = "role_id"),
-            inverseJoinColumns = @JoinColumn(name = "permission_id")
+            joinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id", referencedColumnName = "id")
     )
     private Set<Permission> permissions = new HashSet<>();
 }

--- a/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
+++ b/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
@@ -1,10 +1,10 @@
 -- ROLES
 CREATE TABLE roles
 (
-    role_id BINARY(16) NOT NULL,
-    name    VARCHAR(100) NOT NULL,
+    id   BINARY(16) NOT NULL,
+    name VARCHAR(100) NOT NULL,
 
-    CONSTRAINT pk_roles PRIMARY KEY (role_id),
+    CONSTRAINT pk_roles PRIMARY KEY (id),
     CONSTRAINT ux_roles_name UNIQUE (name)
 ) ENGINE=InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -13,10 +13,10 @@ CREATE TABLE roles
 -- PERMISSIONS
 CREATE TABLE permissions
 (
-    permission_id BINARY(16) NOT NULL,
-    name          VARCHAR(100) NOT NULL,
+    id   BINARY(16) NOT NULL,
+    name VARCHAR(100) NOT NULL,
 
-    CONSTRAINT pk_permissions PRIMARY KEY (permission_id),
+    CONSTRAINT pk_permissions PRIMARY KEY (id),
     CONSTRAINT ux_permissions_name UNIQUE (name)
 ) ENGINE=InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -30,7 +30,7 @@ CREATE TABLE user_roles
 
     CONSTRAINT pk_user_roles PRIMARY KEY (user_id, role_id),
     CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users_profile (user_id),
-    CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles (role_id)
+    CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles (id)
 ) ENGINE=InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;
@@ -42,8 +42,8 @@ CREATE TABLE role_permissions
     permission_id BINARY(16) NOT NULL,
 
     CONSTRAINT pk_role_permissions PRIMARY KEY (role_id, permission_id),
-    CONSTRAINT fk_role_permissions_role FOREIGN KEY (role_id) REFERENCES roles (role_id),
-    CONSTRAINT fk_role_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions (permission_id)
+    CONSTRAINT fk_role_permissions_role FOREIGN KEY (role_id) REFERENCES roles (id),
+    CONSTRAINT fk_role_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions (id)
 ) ENGINE=InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## Summary
- generate time-based UUID identifiers for roles and permissions
- align database migration with new id columns
- update controllers to use generated id in responses

## Testing
- `mvn -q -pl user-service -am test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689c482088a4832d9cf646ea0d35fc22