### PR TITLE
feat(user): add ACL matrix endpoints and persistence

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/AclController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/AclController.java
@@ -1,0 +1,37 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.*;
+import morning.com.services.user.service.AclService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user")
+public class AclController {
+    private final AclService service;
+
+    public AclController(AclService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/acl-matrix")
+    public ResponseEntity<ApiResponse<MatrixResponse>> getMatrix() {
+        return ApiResponse.success(MessageKeys.SUCCESS, service.getMatrix());
+    }
+
+    @PatchMapping("/roles/{roleId}/permissions/{permId}")
+    public ResponseEntity<ApiResponse<Void>> toggle(@PathVariable UUID roleId,
+                                                     @PathVariable UUID permId,
+                                                     @RequestBody GrantRequest request) {
+        service.setGrant(roleId, permId, request.granted());
+        return ApiResponse.success(MessageKeys.SUCCESS);
+    }
+
+    @PostMapping("/acl-matrix")
+    public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody BulkRequest request) {
+        service.applyBulk(request.operations());
+        return ApiResponse.success(MessageKeys.SUCCESS);
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/dto/BulkOp.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/BulkOp.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record BulkOp(UUID roleId, UUID permissionId, boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/BulkRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/BulkRequest.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.List;
+
+public record BulkRequest(List<BulkOp> operations) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/Edge.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/Edge.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record Edge(UUID roleId, UUID permissionId) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/GrantRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/GrantRequest.java
@@ -1,0 +1,3 @@
+package morning.com.services.user.dto;
+
+public record GrantRequest(boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/MatrixResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/MatrixResponse.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.List;
+
+public record MatrixResponse(List<RoleDTO> roles, List<PermissionDTO> permissions, List<Edge> grants) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionDTO.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionDTO.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record PermissionDTO(UUID id, String code, String section, String label) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleDTO.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleDTO.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record RoleDTO(UUID id, String name) {}

--- a/user-service/src/main/java/morning/com/services/user/entity/Permission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Permission.java
@@ -1,15 +1,11 @@
 package morning.com.services.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.*;
 import org.hibernate.type.SqlTypes;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Getter
@@ -28,5 +24,19 @@ public class Permission {
     private UUID id;
 
     @Column(nullable = false, unique = true, length = 100)
-    private String name;
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String section;
+
+    @Column(nullable = false, length = 100)
+    private String label;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
 }

--- a/user-service/src/main/java/morning/com/services/user/entity/Permission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Permission.java
@@ -1,8 +1,15 @@
 package morning.com.services.user.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;

--- a/user-service/src/main/java/morning/com/services/user/entity/Role.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Role.java
@@ -1,8 +1,15 @@
 package morning.com.services.user.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;

--- a/user-service/src/main/java/morning/com/services/user/entity/Role.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Role.java
@@ -2,10 +2,10 @@ package morning.com.services.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.*;
 import org.hibernate.type.SqlTypes;
 
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -27,6 +27,17 @@ public class Role {
 
     @Column(nullable = false, unique = true, length = 100)
     private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
 
     @ManyToMany
     @JoinTable(

--- a/user-service/src/main/java/morning/com/services/user/entity/RolePermission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/RolePermission.java
@@ -1,0 +1,59 @@
+package morning.com.services.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Simple entity representing the {@code role_permissions} join table.
+ * <p>
+ *   JPA requires repositories to be tied to managed entity types. The original
+ *   implementation used {@link Object} as the domain type which caused
+ *   Spring Data to fail startup with a "Not a managed type" error. By mapping
+ *   the join table as an entity we allow Spring to create a repository proxy
+ *   without loading the entire {@link Role} or {@link Permission} graph.
+ * </p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "role_permissions")
+public class RolePermission {
+
+    @EmbeddedId
+    private Id id;
+
+    /**
+     * Composite identifier for a row in {@code role_permissions}.
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Embeddable
+    public static class Id implements Serializable {
+
+        @JdbcTypeCode(SqlTypes.BINARY)
+        @Column(name = "role_id", columnDefinition = "BINARY(16)")
+        private UUID roleId;
+
+        @JdbcTypeCode(SqlTypes.BINARY)
+        @Column(name = "permission_id", columnDefinition = "BINARY(16)")
+        private UUID permissionId;
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -1,9 +1,15 @@
 package morning.com.services.user.repository;
 
+import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.entity.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PermissionRepository extends JpaRepository<Permission, UUID> {
+
+    @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
+    List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
 }

--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -3,13 +3,11 @@ package morning.com.services.user.repository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.UUID;
 
-@Repository
-public interface RolePermissionRepository extends Repository<morning.com.services.user.entity.Role, UUID> {
+public interface RolePermissionRepository extends Repository<Object, UUID> {
 
     interface EdgeView {
         UUID getRoleId();

--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -1,5 +1,6 @@
 package morning.com.services.user.repository;
 
+import morning.com.services.user.entity.RolePermission;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -7,7 +8,7 @@ import org.springframework.data.repository.Repository;
 import java.util.List;
 import java.util.UUID;
 
-public interface RolePermissionRepository extends Repository<Object, UUID> {
+public interface RolePermissionRepository extends Repository<RolePermission, RolePermission.Id> {
 
     interface EdgeView {
         UUID getRoleId();

--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -1,0 +1,29 @@
+package morning.com.services.user.repository;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface RolePermissionRepository extends Repository<morning.com.services.user.entity.Role, UUID> {
+
+    interface EdgeView {
+        UUID getRoleId();
+        UUID getPermissionId();
+    }
+
+    @Query(value = "select role_id as roleId, permission_id as permissionId from role_permissions", nativeQuery = true)
+    List<EdgeView> findAllEdges();
+
+    @Modifying
+    @Query(value = "insert into role_permissions(role_id, permission_id) values (?1, ?2) on duplicate key update permission_id = permission_id", nativeQuery = true)
+    void grant(UUID roleId, UUID permId);
+
+    @Modifying
+    @Query(value = "delete from role_permissions where role_id = ?1 and permission_id = ?2", nativeQuery = true)
+    void revoke(UUID roleId, UUID permId);
+}

--- a/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
@@ -1,9 +1,15 @@
 package morning.com.services.user.repository;
 
+import morning.com.services.user.dto.RoleDTO;
 import morning.com.services.user.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+    @Query("select new morning.com.services.user.dto.RoleDTO(r.id, r.name) from Role r order by r.name")
+    List<RoleDTO> findAllProjectedBy();
 }

--- a/user-service/src/main/java/morning/com/services/user/service/AclService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/AclService.java
@@ -1,0 +1,51 @@
+package morning.com.services.user.service;
+
+import morning.com.services.user.dto.*;
+import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.repository.RolePermissionRepository;
+import morning.com.services.user.repository.RoleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class AclService {
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+    private final RolePermissionRepository rolePermissionRepository;
+
+    public AclService(RoleRepository roleRepository,
+                      PermissionRepository permissionRepository,
+                      RolePermissionRepository rolePermissionRepository) {
+        this.roleRepository = roleRepository;
+        this.permissionRepository = permissionRepository;
+        this.rolePermissionRepository = rolePermissionRepository;
+    }
+
+    public MatrixResponse getMatrix() {
+        List<RoleDTO> roles = roleRepository.findAllProjectedBy();
+        List<PermissionDTO> permissions = permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc();
+        List<Edge> edges = rolePermissionRepository.findAllEdges().stream()
+                .map(e -> new Edge(e.getRoleId(), e.getPermissionId()))
+                .toList();
+        return new MatrixResponse(roles, permissions, edges);
+    }
+
+    @Transactional
+    public void setGrant(UUID roleId, UUID permId, boolean granted) {
+        if (granted) {
+            rolePermissionRepository.grant(roleId, permId);
+        } else {
+            rolePermissionRepository.revoke(roleId, permId);
+        }
+    }
+
+    @Transactional
+    public void applyBulk(List<BulkOp> ops) {
+        for (BulkOp op : ops) {
+            setGrant(op.roleId(), op.permissionId(), op.granted());
+        }
+    }
+}

--- a/user-service/src/main/resources/db/migration/V3__roles_permissions_metadata.sql
+++ b/user-service/src/main/resources/db/migration/V3__roles_permissions_metadata.sql
@@ -1,0 +1,24 @@
+-- Add metadata columns to roles
+ALTER TABLE roles
+    ADD COLUMN description VARCHAR(255) NULL,
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- Update permissions structure
+ALTER TABLE permissions
+    DROP INDEX ux_permissions_name,
+    CHANGE COLUMN name code VARCHAR(100) NOT NULL,
+    ADD COLUMN section VARCHAR(100) NOT NULL,
+    ADD COLUMN label VARCHAR(100) NOT NULL,
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    ADD CONSTRAINT ux_permissions_code UNIQUE (code);
+
+-- Ensure role_permissions cascades on delete
+ALTER TABLE role_permissions
+    DROP FOREIGN KEY fk_role_permissions_role,
+    DROP FOREIGN KEY fk_role_permissions_permission;
+
+ALTER TABLE role_permissions
+    ADD CONSTRAINT fk_role_permissions_role FOREIGN KEY (role_id) REFERENCES roles (id) ON DELETE CASCADE,
+    ADD CONSTRAINT fk_role_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE;

--- a/user-service/src/test/java/morning/com/services/user/service/AclServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/AclServiceTest.java
@@ -1,0 +1,79 @@
+package morning.com.services.user.service;
+
+import morning.com.services.user.dto.Edge;
+import morning.com.services.user.dto.MatrixResponse;
+import morning.com.services.user.dto.PermissionDTO;
+import morning.com.services.user.dto.RoleDTO;
+import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.repository.RolePermissionRepository;
+import morning.com.services.user.repository.RoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AclServiceTest {
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private PermissionRepository permissionRepository;
+
+    @Mock
+    private RolePermissionRepository rolePermissionRepository;
+
+    private AclService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AclService(roleRepository, permissionRepository, rolePermissionRepository);
+    }
+
+    @Test
+    void setGrantDelegatesToRepository() {
+        UUID roleId = UUID.randomUUID();
+        UUID permId = UUID.randomUUID();
+
+        service.setGrant(roleId, permId, true);
+        verify(rolePermissionRepository).grant(roleId, permId);
+
+        service.setGrant(roleId, permId, false);
+        verify(rolePermissionRepository).revoke(roleId, permId);
+
+        verifyNoMoreInteractions(rolePermissionRepository);
+    }
+
+    @Test
+    void getMatrixCombinesDataFromRepositories() {
+        RoleDTO role = new RoleDTO(UUID.randomUUID(), "admin");
+        PermissionDTO perm = new PermissionDTO(UUID.randomUUID(), "code", "sec", "label");
+
+        RolePermissionRepository.EdgeView edge = mock(RolePermissionRepository.EdgeView.class);
+        when(edge.getRoleId()).thenReturn(role.id());
+        when(edge.getPermissionId()).thenReturn(perm.id());
+
+        when(roleRepository.findAllProjectedBy()).thenReturn(List.of(role));
+        when(permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
+        when(rolePermissionRepository.findAllEdges()).thenReturn(List.of(edge));
+
+        MatrixResponse matrix = service.getMatrix();
+
+        assertEquals(List.of(role), matrix.roles());
+        assertEquals(List.of(perm), matrix.permissions());
+        assertEquals(List.of(new Edge(role.id(), perm.id())), matrix.grants());
+
+        verify(roleRepository).findAllProjectedBy();
+        verify(permissionRepository).findAllProjectedByOrderBySectionAscLabelAsc();
+        verify(rolePermissionRepository).findAllEdges();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend role and permission entities with metadata and audit fields
- add repositories, service, and controller to manage role-permission matrix
- add Flyway migration for ACL metadata and cascade deletes

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c53990074832db095c0cef3e2e823