### PR TITLE
Define RolePermission entity to fix repository scanning

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/entity/RolePermission.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/RolePermission.java
@@ -1,0 +1,59 @@
+package morning.com.services.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Simple entity representing the {@code role_permissions} join table.
+ * <p>
+ *   JPA requires repositories to be tied to managed entity types. The original
+ *   implementation used {@link Object} as the domain type which caused
+ *   Spring Data to fail startup with a "Not a managed type" error. By mapping
+ *   the join table as an entity we allow Spring to create a repository proxy
+ *   without loading the entire {@link Role} or {@link Permission} graph.
+ * </p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "role_permissions")
+public class RolePermission {
+
+    @EmbeddedId
+    private Id id;
+
+    /**
+     * Composite identifier for a row in {@code role_permissions}.
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Embeddable
+    public static class Id implements Serializable {
+
+        @JdbcTypeCode(SqlTypes.BINARY)
+        @Column(name = "role_id", columnDefinition = "BINARY(16)")
+        private UUID roleId;
+
+        @JdbcTypeCode(SqlTypes.BINARY)
+        @Column(name = "permission_id", columnDefinition = "BINARY(16)")
+        private UUID permissionId;
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -1,5 +1,6 @@
 package morning.com.services.user.repository;
 
+import morning.com.services.user.entity.RolePermission;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -7,7 +8,7 @@ import org.springframework.data.repository.Repository;
 import java.util.List;
 import java.util.UUID;
 
-public interface RolePermissionRepository extends Repository<Object, UUID> {
+public interface RolePermissionRepository extends Repository<RolePermission, RolePermission.Id> {
 
     interface EdgeView {
         UUID getRoleId();

--- a/user-service/src/test/java/morning/com/services/user/service/AclServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/AclServiceTest.java
@@ -1,0 +1,79 @@
+package morning.com.services.user.service;
+
+import morning.com.services.user.dto.Edge;
+import morning.com.services.user.dto.MatrixResponse;
+import morning.com.services.user.dto.PermissionDTO;
+import morning.com.services.user.dto.RoleDTO;
+import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.repository.RolePermissionRepository;
+import morning.com.services.user.repository.RoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AclServiceTest {
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private PermissionRepository permissionRepository;
+
+    @Mock
+    private RolePermissionRepository rolePermissionRepository;
+
+    private AclService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AclService(roleRepository, permissionRepository, rolePermissionRepository);
+    }
+
+    @Test
+    void setGrantDelegatesToRepository() {
+        UUID roleId = UUID.randomUUID();
+        UUID permId = UUID.randomUUID();
+
+        service.setGrant(roleId, permId, true);
+        verify(rolePermissionRepository).grant(roleId, permId);
+
+        service.setGrant(roleId, permId, false);
+        verify(rolePermissionRepository).revoke(roleId, permId);
+
+        verifyNoMoreInteractions(rolePermissionRepository);
+    }
+
+    @Test
+    void getMatrixCombinesDataFromRepositories() {
+        RoleDTO role = new RoleDTO(UUID.randomUUID(), "admin");
+        PermissionDTO perm = new PermissionDTO(UUID.randomUUID(), "code", "sec", "label");
+
+        RolePermissionRepository.EdgeView edge = mock(RolePermissionRepository.EdgeView.class);
+        when(edge.getRoleId()).thenReturn(role.id());
+        when(edge.getPermissionId()).thenReturn(perm.id());
+
+        when(roleRepository.findAllProjectedBy()).thenReturn(List.of(role));
+        when(permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
+        when(rolePermissionRepository.findAllEdges()).thenReturn(List.of(edge));
+
+        MatrixResponse matrix = service.getMatrix();
+
+        assertEquals(List.of(role), matrix.roles());
+        assertEquals(List.of(perm), matrix.permissions());
+        assertEquals(List.of(new Edge(role.id(), perm.id())), matrix.grants());
+
+        verify(roleRepository).findAllProjectedBy();
+        verify(permissionRepository).findAllProjectedByOrderBySectionAscLabelAsc();
+        verify(rolePermissionRepository).findAllEdges();
+    }
+}
+


### PR DESCRIPTION
## Summary
- model role_permissions join table as a JPA entity
- reference RolePermission in RolePermissionRepository instead of Object
- add unit tests for AclService

## Testing
- `mvn -q -o -pl user-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689c5b6ec8f0832db81c285859aa6ba3