### PR TITLE
Use request DTOs for user endpoints

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -2,6 +2,7 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.dto.PermissionRequest;
 import morning.com.services.user.entity.Permission;
 import morning.com.services.user.service.PermissionService;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,8 @@ public class PermissionController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Permission>> create(@RequestBody Permission permission) {
+    public ResponseEntity<ApiResponse<Permission>> create(@RequestBody PermissionRequest request) {
+        Permission permission = new Permission(null, request.code(), request.section(), request.label(), null, null);
         Permission saved = service.add(permission);
         return ApiResponse.created(
                 MessageKeys.PERMISSION_CREATED,

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -2,9 +2,11 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.dto.RoleRequest;
 import morning.com.services.user.entity.Role;
 import morning.com.services.user.service.PermissionService;
 import morning.com.services.user.service.RoleService;
+import java.util.HashSet;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +25,8 @@ public class RoleController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Role>> create(@RequestBody Role role) {
+    public ResponseEntity<ApiResponse<Role>> create(@RequestBody RoleRequest request) {
+        Role role = new Role(null, request.name(), request.description(), null, null, new HashSet<>());
         Role saved = service.add(role);
         return ApiResponse.created(
                 MessageKeys.ROLE_CREATED,

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -2,9 +2,11 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.dto.UserProfileRequest;
 import morning.com.services.user.entity.UserProfile;
 import morning.com.services.user.service.RoleService;
 import morning.com.services.user.service.UserProfileService;
+import java.util.HashSet;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +25,17 @@ public class UserProfileController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfile profile) {
+    public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfileRequest request) {
+        UserProfile profile = new UserProfile(
+                request.userId(),
+                request.username(),
+                request.email(),
+                request.phone(),
+                request.status(),
+                null,
+                null,
+                new HashSet<>()
+        );
         UserProfile saved = service.add(profile);
         return ApiResponse.created(
                 MessageKeys.PROFILE_CREATED,

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionRequest.java
@@ -1,0 +1,3 @@
+package morning.com.services.user.dto;
+
+public record PermissionRequest(String code, String section, String label) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleRequest.java
@@ -1,0 +1,3 @@
+package morning.com.services.user.dto;
+
+public record RoleRequest(String name, String description) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/UserProfileRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/UserProfileRequest.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record UserProfileRequest(UUID userId, String username, String email, String phone, boolean status) {}


### PR DESCRIPTION
## Summary
- introduce `RoleRequest`, `PermissionRequest`, and `UserProfileRequest` DTOs
- map user-service controllers to consume these request objects instead of entities

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c60a248d4832d974518e63cd10661