### PR TITLE
refactor: use DTOs for permission endpoints

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -138,6 +138,16 @@
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                        <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
                             <version>1.5.5.Final</version>

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -75,6 +75,17 @@
             <version>${spring-openai-mvc.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -119,6 +130,20 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -2,13 +2,15 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
-import morning.com.services.user.entity.Permission;
+import morning.com.services.user.dto.PermissionCreateRequest;
+import morning.com.services.user.dto.PermissionResponse;
+import morning.com.services.user.dto.PermissionUpdateRequest;
 import morning.com.services.user.service.PermissionService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/user/permission")
@@ -20,12 +22,22 @@ public class PermissionController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Permission>> create(@RequestBody Permission permission) {
-        Permission saved = service.add(permission);
+    public ResponseEntity<ApiResponse<PermissionResponse>> create(
+            @Validated @RequestBody PermissionCreateRequest request) {
+        PermissionResponse saved = service.add(request);
         return ApiResponse.created(
                 MessageKeys.PERMISSION_CREATED,
                 saved,
-                "/permission/" + saved.getId()
+                "/permission/" + saved.id()
         );
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<PermissionResponse>> update(
+            @PathVariable UUID id,
+            @Validated @RequestBody PermissionUpdateRequest request) {
+        return service.update(id, request)
+                .map(resp -> ApiResponse.success(MessageKeys.SUCCESS, resp))
+                .orElseGet(() -> ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PERMISSION_NOT_FOUND));
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionCreateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionCreateRequest.java
@@ -1,0 +1,14 @@
+package morning.com.services.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating a Permission.
+ */
+public record PermissionCreateRequest(
+        @NotBlank @Size(max = 100) String code,
+        @NotBlank @Size(max = 100) String section,
+        @NotBlank @Size(max = 100) String label
+) {
+}

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
@@ -1,0 +1,14 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+/**
+ * Response DTO representing a Permission.
+ */
+public record PermissionResponse(
+        UUID id,
+        String code,
+        String section,
+        String label
+) {
+}

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
@@ -2,14 +2,12 @@ package morning.com.services.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.UUID;
 
 /**
  * DTO for updating an existing Permission.
- * The {@code id} field is ignored by the service; the identifier should come from the path variable.
+ * The identifier is provided via the path variable; this request contains only updatable fields.
  */
 public record PermissionUpdateRequest(
-        UUID id,
         @NotBlank @Size(max = 100) String section,
         @NotBlank @Size(max = 100) String label
 ) {

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
@@ -1,0 +1,16 @@
+package morning.com.services.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+/**
+ * DTO for updating an existing Permission.
+ * The {@code id} field is ignored by the service; the identifier should come from the path variable.
+ */
+public record PermissionUpdateRequest(
+        UUID id,
+        @NotBlank @Size(max = 100) String section,
+        @NotBlank @Size(max = 100) String label
+) {
+}

--- a/user-service/src/main/java/morning/com/services/user/exception/FieldValidationException.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/FieldValidationException.java
@@ -1,0 +1,15 @@
+package morning.com.services.user.exception;
+
+public class FieldValidationException extends RuntimeException {
+    private final String field;
+
+    public FieldValidationException(String field, String message) {
+        super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
@@ -4,21 +4,32 @@ import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
-        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage, (a, b) -> a));
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, errors);
+    }
+
+    @ExceptionHandler(FieldValidationException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleFieldValidation(FieldValidationException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, Map.of(ex.getField(), ex.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
-        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, Map.of("error", ex.getMessage()));
     }
 }
 

--- a/user-service/src/main/java/morning/com/services/user/mapper/PermissionMapper.java
+++ b/user-service/src/main/java/morning/com/services/user/mapper/PermissionMapper.java
@@ -1,0 +1,29 @@
+package morning.com.services.user.mapper;
+
+import morning.com.services.user.dto.PermissionCreateRequest;
+import morning.com.services.user.dto.PermissionUpdateRequest;
+import morning.com.services.user.dto.PermissionResponse;
+import morning.com.services.user.entity.Permission;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+/**
+ * MapStruct mapper for converting between Permission entities and DTOs.
+ */
+@Mapper(componentModel = "spring")
+public interface PermissionMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Permission toEntity(PermissionCreateRequest request);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "code", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    void update(@MappingTarget Permission permission, PermissionUpdateRequest request);
+
+    PermissionResponse toResponse(Permission permission);
+}

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -12,4 +12,6 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
 
     @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
     List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
+
+    boolean existsByCode(String code);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -1,7 +1,11 @@
 package morning.com.services.user.service;
 
 import jakarta.transaction.Transactional;
+import morning.com.services.user.dto.PermissionCreateRequest;
+import morning.com.services.user.dto.PermissionUpdateRequest;
+import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.entity.Permission;
+import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
 import org.springframework.stereotype.Service;
 
@@ -11,14 +15,28 @@ import java.util.UUID;
 @Service
 public class PermissionService {
     private final PermissionRepository repository;
+    private final PermissionMapper mapper;
 
-    public PermissionService(PermissionRepository repository) {
+    public PermissionService(PermissionRepository repository, PermissionMapper mapper) {
         this.repository = repository;
+        this.mapper = mapper;
     }
 
     @Transactional
-    public Permission add(Permission permission) {
-        return repository.save(permission);
+    public PermissionResponse add(PermissionCreateRequest request) {
+        Permission entity = mapper.toEntity(request);
+        Permission saved = repository.save(entity);
+        return mapper.toResponse(saved);
+    }
+
+    @Transactional
+    public Optional<PermissionResponse> update(UUID id, PermissionUpdateRequest request) {
+        return repository.findById(id)
+                .map(entity -> {
+                    mapper.update(entity, request);
+                    Permission updated = repository.save(entity);
+                    return mapper.toResponse(updated);
+                });
     }
 
     public Optional<Permission> findById(UUID id) {

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -7,6 +7,7 @@ import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.entity.Permission;
 import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.exception.FieldValidationException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -24,6 +25,9 @@ public class PermissionService {
 
     @Transactional
     public PermissionResponse add(PermissionCreateRequest request) {
+        if (repository.existsByCode(request.code())) {
+            throw new FieldValidationException("code", "already exists");
+        }
         Permission entity = mapper.toEntity(request);
         Permission saved = repository.save(entity);
         return mapper.toResponse(saved);

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -26,7 +26,7 @@ public class PermissionService {
     @Transactional
     public PermissionResponse add(PermissionCreateRequest request) {
         if (repository.existsByCode(request.code())) {
-            throw new FieldValidationException("code", "already exists");
+            throw new FieldValidationException("code", "already.exists");
         }
         Permission entity = mapper.toEntity(request);
         Permission saved = repository.save(entity);

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerValidationTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerValidationTest.java
@@ -1,0 +1,51 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.service.PermissionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PermissionController.class)
+class PermissionControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PermissionService service;
+
+    @Test
+    void createWhenInvalidFieldsReturnsErrors() throws Exception {
+        String payload = "{\"code\":\"\",\"section\":\"\",\"label\":\"\"}";
+        mockMvc.perform(post("/user/permission")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.code").exists())
+                .andExpect(jsonPath("$.data.section").exists())
+                .andExpect(jsonPath("$.data.label").exists());
+    }
+
+    @Test
+    void createWhenDuplicateCodeReturnsFieldError() throws Exception {
+        when(service.add(any())).thenThrow(new FieldValidationException("code", "already exists"));
+        String payload = "{\"code\":\"A\",\"section\":\"S\",\"label\":\"L\"}";
+        mockMvc.perform(post("/user/permission")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.code").value("already exists"));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce DTOs for permission create/update/response and MapStruct mapper
- refactor permission service and controller to use DTOs
- add MapStruct dependencies and annotation processing

## Testing
- `mvn -q -pl user-service -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:3.5.4 due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c73e0c088832d98c95e2fbf06001d