### PR TITLE
Add Lombok annotation processors to support MapStruct mappings

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -138,6 +138,16 @@
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                        <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
                             <version>1.5.5.Final</version>


### PR DESCRIPTION
## Summary
- configure maven-compiler-plugin to run Lombok and MapStruct processors together

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for spring-boot-subscription-platform)*

------
https://chatgpt.com/codex/tasks/task_e_689c76bb7bd4832d924388be9f967e1e