### PR TITLE
Remove unused id from PermissionUpdateRequest

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionUpdateRequest.java
@@ -2,14 +2,12 @@ package morning.com.services.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.UUID;
 
 /**
  * DTO for updating an existing Permission.
- * The {@code id} field is ignored by the service; the identifier should come from the path variable.
+ * The identifier is provided via the path variable; this request contains only updatable fields.
  */
 public record PermissionUpdateRequest(
-        UUID id,
         @NotBlank @Size(max = 100) String section,
         @NotBlank @Size(max = 100) String label
 ) {


### PR DESCRIPTION
## Summary
- remove redundant id field from PermissionUpdateRequest; rely on path variable for identifier

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c7c9d99f0832db53d932727f59485