### PR TITLE
Improve permission validation messaging

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/exception/FieldValidationException.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/FieldValidationException.java
@@ -1,0 +1,15 @@
+package morning.com.services.user.exception;
+
+public class FieldValidationException extends RuntimeException {
+    private final String field;
+
+    public FieldValidationException(String field, String message) {
+        super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
@@ -4,21 +4,32 @@ import morning.com.services.user.dto.ApiResponse;
 import morning.com.services.user.dto.MessageKeys;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
-        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage, (a, b) -> a));
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, errors);
+    }
+
+    @ExceptionHandler(FieldValidationException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleFieldValidation(FieldValidationException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, Map.of(ex.getField(), ex.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
-        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR);
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, Map.of("error", ex.getMessage()));
     }
 }
 

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -12,4 +12,6 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
 
     @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
     List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
+
+    boolean existsByCode(String code);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -7,6 +7,7 @@ import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.entity.Permission;
 import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.exception.FieldValidationException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -24,6 +25,9 @@ public class PermissionService {
 
     @Transactional
     public PermissionResponse add(PermissionCreateRequest request) {
+        if (repository.existsByCode(request.code())) {
+            throw new FieldValidationException("code", "already exists");
+        }
         Permission entity = mapper.toEntity(request);
         Permission saved = repository.save(entity);
         return mapper.toResponse(saved);

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerValidationTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerValidationTest.java
@@ -1,0 +1,51 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.service.PermissionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PermissionController.class)
+class PermissionControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PermissionService service;
+
+    @Test
+    void createWhenInvalidFieldsReturnsErrors() throws Exception {
+        String payload = "{\"code\":\"\",\"section\":\"\",\"label\":\"\"}";
+        mockMvc.perform(post("/user/permission")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.code").exists())
+                .andExpect(jsonPath("$.data.section").exists())
+                .andExpect(jsonPath("$.data.label").exists());
+    }
+
+    @Test
+    void createWhenDuplicateCodeReturnsFieldError() throws Exception {
+        when(service.add(any())).thenThrow(new FieldValidationException("code", "already exists"));
+        String payload = "{\"code\":\"A\",\"section\":\"S\",\"label\":\"L\"}";
+        mockMvc.perform(post("/user/permission")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.code").value("already exists"));
+    }
+}


### PR DESCRIPTION
## Summary
- refine validation error responses via a new `FieldValidationException`
- prevent duplicate permission codes in `PermissionService`
- ensure controllers return detailed field errors for invalid requests

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d4fb4e25c832d82c0d5f2ae82d428