### PR TITLE
fix: use JPQL for role-permission edge projection

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -15,7 +15,7 @@ public interface RolePermissionRepository extends Repository<RolePermission, Rol
         UUID getPermissionId();
     }
 
-    @Query(value = "select role_id as roleId, permission_id as permissionId from role_permissions", nativeQuery = true)
+    @Query("select rp.id.roleId as roleId, rp.id.permissionId as permissionId from RolePermission rp")
     List<EdgeView> findAllEdges();
 
     @Modifying


### PR DESCRIPTION
## Summary
- avoid native byte array results when reading role permission edges

## Testing
- `mvn -q -pl user-service -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d608909a8832d9f1ec49bcff0e485