### PR TITLE
refactor: enhance role creation flow

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -1,9 +1,9 @@
 package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.*;
-import morning.com.services.user.entity.Role;
 import morning.com.services.user.service.RoleService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -18,12 +18,13 @@ public class RoleController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Role>> create(@RequestBody Role role) {
-        Role saved = service.add(role);
+    public ResponseEntity<ApiResponse<RoleResponse>> create(
+            @Validated @RequestBody RoleCreateRequest request) {
+        RoleResponse saved = service.add(request);
         return ApiResponse.created(
                 MessageKeys.ROLE_CREATED,
                 saved,
-                "/role/" + saved.getId()
+                "/role/" + saved.id()
         );
     }
 

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleCreateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleCreateRequest.java
@@ -1,0 +1,13 @@
+package morning.com.services.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating a Role.
+ */
+public record RoleCreateRequest(
+        @NotBlank @Size(max = 100) String name,
+        @Size(max = 255) String description
+) {}
+

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleResponse.java
@@ -1,0 +1,13 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+/**
+ * Response DTO representing a Role.
+ */
+public record RoleResponse(
+        UUID id,
+        String name,
+        String description
+) {}
+

--- a/user-service/src/main/java/morning/com/services/user/mapper/RoleMapper.java
+++ b/user-service/src/main/java/morning/com/services/user/mapper/RoleMapper.java
@@ -1,0 +1,23 @@
+package morning.com.services.user.mapper;
+
+import morning.com.services.user.dto.RoleCreateRequest;
+import morning.com.services.user.dto.RoleResponse;
+import morning.com.services.user.entity.Role;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * MapStruct mapper for converting between Role entities and DTOs.
+ */
+@Mapper(componentModel = "spring")
+public interface RoleMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "permissions", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Role toEntity(RoleCreateRequest request);
+
+    RoleResponse toResponse(Role role);
+}
+

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import morning.com.services.user.dto.*;
 import morning.com.services.user.entity.Role;
 import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.mapper.RoleMapper;
 import morning.com.services.user.repository.PermissionRepository;
 import morning.com.services.user.repository.RolePermissionRepository;
 import morning.com.services.user.repository.RoleRepository;
@@ -20,20 +21,25 @@ public class RoleService {
     private final PermissionRepository permissionRepository;
     private final UserProfileRepository userRepository;
     private final RolePermissionRepository rolePermissionRepository;
+    private final RoleMapper mapper;
 
     public RoleService(RoleRepository roleRepository,
                        PermissionRepository permissionRepository,
                        UserProfileRepository userRepository,
-                       RolePermissionRepository rolePermissionRepository) {
+                       RolePermissionRepository rolePermissionRepository,
+                       RoleMapper mapper) {
         this.roleRepository = roleRepository;
         this.permissionRepository = permissionRepository;
         this.userRepository = userRepository;
         this.rolePermissionRepository = rolePermissionRepository;
+        this.mapper = mapper;
     }
 
     @Transactional
-    public Role add(Role role) {
-        return roleRepository.save(role);
+    public RoleResponse add(RoleCreateRequest request) {
+        Role entity = mapper.toEntity(request);
+        Role saved = roleRepository.save(entity);
+        return mapper.toResponse(saved);
     }
 
     public Optional<Role> findById(UUID id) {

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -35,11 +35,14 @@ class RoleServiceTest {
     @Mock
     private UserProfileRepository userRepository;
 
+    @Mock
+    private morning.com.services.user.mapper.RoleMapper roleMapper;
+
     private RoleService service;
 
     @BeforeEach
     void setUp() {
-        service = new RoleService(roleRepository, permissionRepository, userRepository, rolePermissionRepository);
+        service = new RoleService(roleRepository, permissionRepository, userRepository, rolePermissionRepository, roleMapper);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- handle role creation via dedicated request/response DTOs
- add mapper and service logic to convert and return new role DTO
- adjust tests to account for mapper dependency

## Testing
- `mvn -q -pl user-service test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689d9d366584832d88c2d88869a38631