### PR TITLE
Validate duplicate role names

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
@@ -12,4 +12,6 @@ public interface RoleRepository extends JpaRepository<Role, UUID> {
 
     @Query("select new morning.com.services.user.dto.RoleDTO(r.id, r.name) from Role r order by r.name")
     List<RoleDTO> findAllProjectedBy();
+
+    boolean existsByName(String name);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import morning.com.services.user.dto.*;
 import morning.com.services.user.entity.Role;
 import morning.com.services.user.entity.UserProfile;
+import morning.com.services.user.exception.FieldValidationException;
 import morning.com.services.user.mapper.RoleMapper;
 import morning.com.services.user.repository.PermissionRepository;
 import morning.com.services.user.repository.RolePermissionRepository;
@@ -37,6 +38,9 @@ public class RoleService {
 
     @Transactional
     public RoleResponse add(RoleCreateRequest request) {
+        if (roleRepository.existsByName(request.name())) {
+            throw new FieldValidationException("name", "already.exists");
+        }
         Role entity = mapper.toEntity(request);
         Role saved = roleRepository.save(entity);
         return mapper.toResponse(saved);

--- a/user-service/src/test/java/morning/com/services/user/controller/RoleControllerValidationTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/RoleControllerValidationTest.java
@@ -1,0 +1,49 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.service.RoleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(RoleController.class)
+class RoleControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoleService service;
+
+    @Test
+    void createWhenInvalidFieldsReturnsErrors() throws Exception {
+        String payload = "{\"name\":\"\",\"description\":\"\"}";
+        mockMvc.perform(post("/user/role")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.name").exists());
+    }
+
+    @Test
+    void createWhenDuplicateNameReturnsFieldError() throws Exception {
+        when(service.add(any())).thenThrow(new FieldValidationException("name", "already exists"));
+        String payload = "{\"name\":\"admin\",\"description\":\"\"}";
+        mockMvc.perform(post("/user/role")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
+                .andExpect(jsonPath("$.data.name").value("already exists"));
+    }
+}

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -3,7 +3,9 @@ package morning.com.services.user.service;
 import morning.com.services.user.dto.Edge;
 import morning.com.services.user.dto.MatrixResponse;
 import morning.com.services.user.dto.PermissionDTO;
+import morning.com.services.user.dto.RoleCreateRequest;
 import morning.com.services.user.dto.RoleDTO;
+import morning.com.services.user.exception.FieldValidationException;
 import morning.com.services.user.repository.PermissionRepository;
 import morning.com.services.user.repository.RolePermissionRepository;
 import morning.com.services.user.repository.RoleRepository;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,6 +46,17 @@ class RoleServiceTest {
     @BeforeEach
     void setUp() {
         service = new RoleService(roleRepository, permissionRepository, userRepository, rolePermissionRepository, roleMapper);
+    }
+
+    @Test
+    void addWhenNameExistsThrowsFieldValidationException() {
+        RoleCreateRequest request = new RoleCreateRequest("admin", null);
+        when(roleRepository.existsByName("admin")).thenReturn(true);
+
+        assertThrows(FieldValidationException.class, () -> service.add(request));
+
+        verify(roleRepository).existsByName("admin");
+        verifyNoMoreInteractions(roleRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- prevent creating roles with duplicate names in `RoleService`
- expose `existsByName` lookup on `RoleRepository`
- add service and controller tests for duplicate role name validation

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689da578b244832dae6faa15b98b6ec2