### PR TITLE
feat: add swagger API titles

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
+++ b/auth-service/src/main/java/morning/com/services/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package morning.com.services.auth.controller;
 
 import io.jsonwebtoken.JwtException;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import morning.com.services.auth.dto.*;
 import morning.com.services.auth.service.JwtService;
@@ -28,6 +29,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
+    @Operation(summary = "Register new user account")
     public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody AuthRequest request) {
         try {
             userService.register(request.username(), request.password());
@@ -38,6 +40,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
+    @Operation(summary = "Authenticate user and issue tokens")
     public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest request,
                                                           HttpServletRequest http) {
         if (userService.authenticate(request.username(), request.password())) {
@@ -53,6 +56,7 @@ public class AuthController {
     }
 
     @GetMapping("/me")
+    @Operation(summary = "Get authenticated user info")
     public ResponseEntity<ApiResponse<UserInfo>> me(
             @RequestHeader(name = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
 
@@ -78,6 +82,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "Refresh access token")
     public ResponseEntity<ApiResponse<AuthResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
         try {
             var rotation = refreshTokenService.verifyAndRotate(request.refreshToken());
@@ -92,6 +97,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "Log out user")
     public ResponseEntity<ApiResponse<Void>> logout(@Valid @RequestBody RefreshRequest request) {
         try {
             refreshTokenService.revoke(request.refreshToken());
@@ -102,6 +108,7 @@ public class AuthController {
     }
 
     @PostMapping("/change-password")
+    @Operation(summary = "Change user password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
             @RequestHeader(name = HttpHeaders.AUTHORIZATION, required = false) String authorization,
             @Valid @RequestBody PasswordChangeRequest request) {

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -6,6 +6,7 @@ import morning.com.services.user.dto.PermissionCreateRequest;
 import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.dto.PermissionUpdateRequest;
 import morning.com.services.user.service.PermissionService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -22,6 +23,7 @@ public class PermissionController {
     }
 
     @PostMapping
+    @Operation(summary = "Create new permission")
     public ResponseEntity<ApiResponse<PermissionResponse>> create(
             @Validated @RequestBody PermissionCreateRequest request) {
         PermissionResponse saved = service.add(request);
@@ -33,6 +35,7 @@ public class PermissionController {
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Update existing permission")
     public ResponseEntity<ApiResponse<PermissionResponse>> update(
             @PathVariable UUID id,
             @Validated @RequestBody PermissionUpdateRequest request) {

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -2,6 +2,7 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.*;
 import morning.com.services.user.service.RoleService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +19,7 @@ public class RoleController {
     }
 
     @PostMapping
+    @Operation(summary = "Create new role")
     public ResponseEntity<ApiResponse<RoleResponse>> create(
             @Validated @RequestBody RoleCreateRequest request) {
         RoleResponse saved = service.add(request);
@@ -29,11 +31,13 @@ public class RoleController {
     }
 
     @GetMapping("/acl-matrix")
+    @Operation(summary = "Get ACL matrix")
     public ResponseEntity<ApiResponse<MatrixResponse>> getMatrix() {
         return ApiResponse.success(MessageKeys.SUCCESS, service.getMatrix());
     }
 
     @PatchMapping("/{roleId}/permissions/{permId}")
+    @Operation(summary = "Grant or revoke role permission")
     public ResponseEntity<ApiResponse<Void>> toggle(@PathVariable UUID roleId,
                                                     @PathVariable UUID permId,
                                                     @RequestBody GrantRequest request) {
@@ -42,6 +46,7 @@ public class RoleController {
     }
 
     @PostMapping("/acl-matrix")
+    @Operation(summary = "Apply bulk permission operations")
     public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody BulkRequest request) {
         service.applyBulk(request.operations());
         return ApiResponse.success(MessageKeys.SUCCESS);

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -5,6 +5,7 @@ import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.entity.UserProfile;
 import morning.com.services.user.service.RoleService;
 import morning.com.services.user.service.UserProfileService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,7 @@ public class UserProfileController {
     }
 
     @PostMapping
+    @Operation(summary = "Create new user profile")
     public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfile profile) {
         UserProfile saved = service.add(profile);
         return ApiResponse.created(
@@ -33,6 +35,7 @@ public class UserProfileController {
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Get user profile by ID")
     public ResponseEntity<ApiResponse<UserProfile>> get(@PathVariable UUID id) {
         return service.findById(id)
                 .map(profile -> ApiResponse.success(MessageKeys.SUCCESS, profile))
@@ -40,6 +43,7 @@ public class UserProfileController {
     }
 
     @PostMapping("/{id}/roles/{roleId}")
+    @Operation(summary = "Add role to user")
     public ResponseEntity<ApiResponse<UserProfile>> addRole(@PathVariable UUID id, @PathVariable UUID roleId) {
         if (service.findById(id).isEmpty()) {
             return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PROFILE_NOT_FOUND);


### PR DESCRIPTION
## Summary
- document auth endpoints with Swagger operation titles
- add Swagger titles for role, permission, and user profile APIs

## Testing
- `mvn -q -pl auth-service,user-service test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689da985c648832dbdf47b3967464df2