### PR TITLE
refactor: clarify role-permission DTO names

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -40,15 +40,15 @@ public class RoleController {
     @Operation(summary = "Grant or revoke role permission")
     public ResponseEntity<ApiResponse<Void>> toggle(@PathVariable UUID roleId,
                                                     @PathVariable UUID permId,
-                                                    @RequestBody GrantRequest request) {
+                                                    @RequestBody RolePermissionGrantRequest request) {
         service.setGrant(roleId, permId, request.granted());
         return ApiResponse.success(MessageKeys.SUCCESS);
     }
 
     @PostMapping("/acl-matrix")
     @Operation(summary = "Apply bulk permission operations")
-    public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody BulkRequest request) {
-        service.applyBulk(request.operations());
+    public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody RolePermissionBulkGrantRequest request) {
+        service.applyBulk(request.changes());
         return ApiResponse.success(MessageKeys.SUCCESS);
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/dto/BulkOp.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/BulkOp.java
@@ -1,5 +1,0 @@
-package morning.com.services.user.dto;
-
-import java.util.UUID;
-
-public record BulkOp(UUID roleId, UUID permissionId, boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/BulkRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/BulkRequest.java
@@ -1,5 +1,0 @@
-package morning.com.services.user.dto;
-
-import java.util.List;
-
-public record BulkRequest(List<BulkOp> operations) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/Edge.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/Edge.java
@@ -1,5 +1,0 @@
-package morning.com.services.user.dto;
-
-import java.util.UUID;
-
-public record Edge(UUID roleId, UUID permissionId) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/GrantRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/GrantRequest.java
@@ -1,3 +1,0 @@
-package morning.com.services.user.dto;
-
-public record GrantRequest(boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/MatrixResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/MatrixResponse.java
@@ -2,4 +2,4 @@ package morning.com.services.user.dto;
 
 import java.util.List;
 
-public record MatrixResponse(List<RoleDTO> roles, List<PermissionDTO> permissions, List<Edge> grants) {}
+public record MatrixResponse(List<RoleDTO> roles, List<PermissionDTO> permissions, List<RolePermissionEdge> grants) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RolePermissionBulkGrantRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RolePermissionBulkGrantRequest.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.List;
+
+public record RolePermissionBulkGrantRequest(List<RolePermissionGrantChange> changes) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RolePermissionEdge.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RolePermissionEdge.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record RolePermissionEdge(UUID roleId, UUID permissionId) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RolePermissionGrantChange.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RolePermissionGrantChange.java
@@ -1,0 +1,5 @@
+package morning.com.services.user.dto;
+
+import java.util.UUID;
+
+public record RolePermissionGrantChange(UUID roleId, UUID permissionId, boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RolePermissionGrantRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RolePermissionGrantRequest.java
@@ -1,0 +1,3 @@
+package morning.com.services.user.dto;
+
+public record RolePermissionGrantRequest(boolean granted) {}

--- a/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RolePermissionRepository.java
@@ -10,13 +10,13 @@ import java.util.UUID;
 
 public interface RolePermissionRepository extends Repository<RolePermission, RolePermission.Id> {
 
-    interface EdgeView {
+    interface RolePermissionEdgeView {
         UUID getRoleId();
         UUID getPermissionId();
     }
 
     @Query("select rp.id.roleId as roleId, rp.id.permissionId as permissionId from RolePermission rp")
-    List<EdgeView> findAllEdges();
+    List<RolePermissionEdgeView> findAllRolePermissionEdges();
 
     @Modifying
     @Query(value = "insert into role_permissions(role_id, permission_id) values (?1, ?2) on duplicate key update permission_id = permission_id", nativeQuery = true)

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -61,8 +61,8 @@ public class RoleService {
     public MatrixResponse getMatrix() {
         List<RoleDTO> roles = roleRepository.findAllProjectedBy();
         List<PermissionDTO> permissions = permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc();
-        List<Edge> edges = rolePermissionRepository.findAllEdges().stream()
-                .map(e -> new Edge(e.getRoleId(), e.getPermissionId()))
+        List<RolePermissionEdge> edges = rolePermissionRepository.findAllRolePermissionEdges().stream()
+                .map(e -> new RolePermissionEdge(e.getRoleId(), e.getPermissionId()))
                 .toList();
         return new MatrixResponse(roles, permissions, edges);
     }
@@ -77,9 +77,9 @@ public class RoleService {
     }
 
     @Transactional
-    public void applyBulk(List<BulkOp> ops) {
-        for (BulkOp op : ops) {
-            setGrant(op.roleId(), op.permissionId(), op.granted());
+    public void applyBulk(List<RolePermissionGrantChange> changes) {
+        for (RolePermissionGrantChange change : changes) {
+            setGrant(change.roleId(), change.permissionId(), change.granted());
         }
     }
 }

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -1,6 +1,6 @@
 package morning.com.services.user.service;
 
-import morning.com.services.user.dto.Edge;
+import morning.com.services.user.dto.RolePermissionEdge;
 import morning.com.services.user.dto.MatrixResponse;
 import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.dto.RoleCreateRequest;
@@ -78,23 +78,23 @@ class RoleServiceTest {
         RoleDTO role = new RoleDTO(UUID.randomUUID(), "admin");
         PermissionDTO perm = new PermissionDTO(UUID.randomUUID(), "code", "sec", "label");
 
-        RolePermissionRepository.EdgeView edge = mock(RolePermissionRepository.EdgeView.class);
+        RolePermissionRepository.RolePermissionEdgeView edge = mock(RolePermissionRepository.RolePermissionEdgeView.class);
         when(edge.getRoleId()).thenReturn(role.id());
         when(edge.getPermissionId()).thenReturn(perm.id());
 
         when(roleRepository.findAllProjectedBy()).thenReturn(List.of(role));
         when(permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
-        when(rolePermissionRepository.findAllEdges()).thenReturn(List.of(edge));
+        when(rolePermissionRepository.findAllRolePermissionEdges()).thenReturn(List.of(edge));
 
         MatrixResponse matrix = service.getMatrix();
 
         assertEquals(List.of(role), matrix.roles());
         assertEquals(List.of(perm), matrix.permissions());
-        assertEquals(List.of(new Edge(role.id(), perm.id())), matrix.grants());
+        assertEquals(List.of(new RolePermissionEdge(role.id(), perm.id())), matrix.grants());
 
         verify(roleRepository).findAllProjectedBy();
         verify(permissionRepository).findAllProjectedByOrderBySectionAscLabelAsc();
-        verify(rolePermissionRepository).findAllEdges();
+        verify(rolePermissionRepository).findAllRolePermissionEdges();
     }
 }
 


### PR DESCRIPTION
## Summary
- rename generic role/permission DTOs for clarity (e.g. `BulkOp` -> `RolePermissionGrantChange`)
- adjust controller, service, repository, and tests to use new names

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689daec8485c832dae3b85038afa4ef9