### PR TITLE
feat: expand permission management

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -10,6 +10,7 @@ import morning.com.services.user.dto.PermissionUpdateRequest;
 import morning.com.services.user.service.PermissionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -30,10 +31,15 @@ public class PermissionController {
     @GetMapping
     @Operation(summary = "List permissions")
     public ResponseEntity<ApiResponse<Page<PermissionResponse>>> list(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "id") String sortBy,
+            @RequestParam(defaultValue = "asc") String direction,
             @RequestParam(required = false) String search) {
-        Page<PermissionResponse> result = service.search(search, PageRequest.of(page, size));
+        Sort sort = direction.equalsIgnoreCase("desc")
+                ? Sort.by(sortBy).descending()
+                : Sort.by(sortBy).ascending();
+        Page<PermissionResponse> result = service.search(search, PageRequest.of(Math.max(page - 1, 0), size, sort));
         return ApiResponse.success(MessageKeys.SUCCESS, result);
     }
 

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
@@ -1,5 +1,6 @@
 package morning.com.services.user.dto;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -9,6 +10,8 @@ public record PermissionResponse(
         UUID id,
         String code,
         String section,
-        String label
+        String label,
+        Instant createdAt,
+        Instant updatedAt
 ) {
 }

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -2,6 +2,8 @@ package morning.com.services.user.repository;
 
 import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.entity.Permission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +16,7 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
     List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
 
     boolean existsByCode(String code);
+
+    Page<Permission> findByCodeContainingIgnoreCaseOrSectionContainingIgnoreCaseOrLabelContainingIgnoreCase(
+            String code, String section, String label, Pageable pageable);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -8,8 +8,11 @@ import morning.com.services.user.entity.Permission;
 import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
 import morning.com.services.user.exception.FieldValidationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -45,5 +48,41 @@ public class PermissionService {
 
     public Optional<Permission> findById(UUID id) {
         return repository.findById(id);
+    }
+
+    public Page<PermissionResponse> search(String search, Pageable pageable) {
+        Page<Permission> page;
+        if (search != null && !search.isBlank()) {
+            page = repository.findByCodeContainingIgnoreCaseOrSectionContainingIgnoreCaseOrLabelContainingIgnoreCase(
+                    search, search, search, pageable);
+        } else {
+            page = repository.findAll(pageable);
+        }
+        return page.map(mapper::toResponse);
+    }
+
+    @Transactional
+    public List<PermissionResponse> addBulk(List<PermissionCreateRequest> requests) {
+        List<Permission> entities = requests.stream().map(req -> {
+            if (repository.existsByCode(req.code())) {
+                throw new FieldValidationException("code", "already.exists");
+            }
+            return mapper.toEntity(req);
+        }).toList();
+        return repository.saveAll(entities).stream().map(mapper::toResponse).toList();
+    }
+
+    @Transactional
+    public boolean delete(UUID id) {
+        if (!repository.existsById(id)) {
+            return false;
+        }
+        repository.deleteById(id);
+        return true;
+    }
+
+    @Transactional
+    public void deleteBulk(List<UUID> ids) {
+        repository.deleteAllByIdInBatch(ids);
     }
 }

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,7 +34,7 @@ class PermissionControllerTest {
 
     @Test
     void listReturnsPermissions() throws Exception {
-        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL");
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL", Instant.now(), Instant.now());
         Page<PermissionResponse> page = new PageImpl<>(List.of(resp), PageRequest.of(0, 10), 1);
         when(service.search(eq("test"), any())).thenReturn(page);
 
@@ -60,7 +61,7 @@ class PermissionControllerTest {
 
     @Test
     void bulkCreateReturnsList() throws Exception {
-        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L");
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L", Instant.now(), Instant.now());
         when(service.addBulk(anyList())).thenReturn(List.of(resp));
         String payload = "[{\"code\":\"C\",\"section\":\"S\",\"label\":\"L\"}]";
         mockMvc.perform(post("/user/permission/_bulk")

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -1,0 +1,83 @@
+package morning.com.services.user.controller;
+
+import morning.com.services.user.dto.MessageKeys;
+import morning.com.services.user.dto.PermissionResponse;
+import morning.com.services.user.service.PermissionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PermissionController.class)
+class PermissionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PermissionService service;
+
+    @Test
+    void listReturnsPermissions() throws Exception {
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL");
+        Page<PermissionResponse> page = new PageImpl<>(List.of(resp), PageRequest.of(0, 10), 1);
+        when(service.search(eq("test"), any())).thenReturn(page);
+
+        mockMvc.perform(get("/user/permission").param("search", "test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].id").value(resp.id().toString()));
+    }
+
+    @Test
+    void deleteReturnsNotFoundWhenMissing() throws Exception {
+        when(service.delete(any())).thenReturn(false);
+        mockMvc.perform(delete("/user/permission/{id}", UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.PERMISSION_NOT_FOUND));
+    }
+
+    @Test
+    void deleteReturnsSuccessWhenFound() throws Exception {
+        when(service.delete(any())).thenReturn(true);
+        mockMvc.perform(delete("/user/permission/{id}", UUID.randomUUID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.SUCCESS));
+    }
+
+    @Test
+    void bulkCreateReturnsList() throws Exception {
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L");
+        when(service.addBulk(anyList())).thenReturn(List.of(resp));
+        String payload = "[{\"code\":\"C\",\"section\":\"S\",\"label\":\"L\"}]";
+        mockMvc.perform(post("/user/permission/_bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(resp.id().toString()));
+    }
+
+    @Test
+    void bulkDeleteReturnsSuccess() throws Exception {
+        doNothing().when(service).deleteBulk(anyList());
+        String payload = "[\"" + UUID.randomUUID() + "\"]";
+        mockMvc.perform(delete("/user/permission/_bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.SUCCESS));
+    }
+}


### PR DESCRIPTION
## Summary
- add permission list endpoint with search and pagination
- support bulk permission creation and deletion
- expose delete endpoint and accompanying service logic

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM due to missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe47cd64832dbc1786d18b5dc129