### PR TITLE
Enable sortable, one-based permission pagination with timestamps

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -10,6 +10,7 @@ import morning.com.services.user.dto.PermissionUpdateRequest;
 import morning.com.services.user.service.PermissionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -30,10 +31,15 @@ public class PermissionController {
     @GetMapping
     @Operation(summary = "List permissions")
     public ResponseEntity<ApiResponse<Page<PermissionResponse>>> list(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "id") String sortBy,
+            @RequestParam(defaultValue = "asc") String direction,
             @RequestParam(required = false) String search) {
-        Page<PermissionResponse> result = service.search(search, PageRequest.of(page, size));
+        Sort sort = direction.equalsIgnoreCase("desc")
+                ? Sort.by(sortBy).descending()
+                : Sort.by(sortBy).ascending();
+        Page<PermissionResponse> result = service.search(search, PageRequest.of(Math.max(page - 1, 0), size, sort));
         return ApiResponse.success(MessageKeys.SUCCESS, result);
     }
 

--- a/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PermissionResponse.java
@@ -1,5 +1,6 @@
 package morning.com.services.user.dto;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -9,6 +10,8 @@ public record PermissionResponse(
         UUID id,
         String code,
         String section,
-        String label
+        String label,
+        Instant createdAt,
+        Instant updatedAt
 ) {
 }

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,7 +34,7 @@ class PermissionControllerTest {
 
     @Test
     void listReturnsPermissions() throws Exception {
-        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL");
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL", Instant.now(), Instant.now());
         Page<PermissionResponse> page = new PageImpl<>(List.of(resp), PageRequest.of(0, 10), 1);
         when(service.search(eq("test"), any())).thenReturn(page);
 
@@ -60,7 +61,7 @@ class PermissionControllerTest {
 
     @Test
     void bulkCreateReturnsList() throws Exception {
-        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L");
+        PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L", Instant.now(), Instant.now());
         when(service.addBulk(anyList())).thenReturn(List.of(resp));
         String payload = "[{\"code\":\"C\",\"section\":\"S\",\"label\":\"L\"}]";
         mockMvc.perform(post("/user/permission/_bulk")


### PR DESCRIPTION
## Summary
- include creation and update timestamps in PermissionResponse
- allow sorting by arbitrary field and use 1-based page numbers for permissions API
- adjust tests for new response fields

## Testing
- `cd sbsp/user-service && mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_689dcea37070832d9a116bc5f27a73fd