### PR TITLE
fix: rename permission bulk endpoints

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -65,7 +65,7 @@ public class PermissionController {
                 .orElseGet(() -> ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PERMISSION_NOT_FOUND));
     }
 
-    @PostMapping("/_bulk")
+    @PostMapping("/bulk")
     @Operation(summary = "Create permissions in bulk")
     public ResponseEntity<ApiResponse<List<PermissionResponse>>> bulkCreate(
             @RequestBody List<@Valid PermissionCreateRequest> requests) {
@@ -80,7 +80,7 @@ public class PermissionController {
                 : ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PERMISSION_NOT_FOUND);
     }
 
-    @DeleteMapping("/_bulk")
+    @DeleteMapping("/bulk")
     @Operation(summary = "Delete permissions in bulk")
     public ResponseEntity<ApiResponse<Void>> bulkDelete(@RequestBody List<UUID> ids) {
         service.deleteBulk(ids);

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -64,7 +64,7 @@ class PermissionControllerTest {
         PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "C", "S", "L", Instant.now(), Instant.now());
         when(service.addBulk(anyList())).thenReturn(List.of(resp));
         String payload = "[{\"code\":\"C\",\"section\":\"S\",\"label\":\"L\"}]";
-        mockMvc.perform(post("/user/permission/_bulk")
+        mockMvc.perform(post("/user/permission/bulk")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
                 .andExpect(status().isOk())
@@ -75,7 +75,7 @@ class PermissionControllerTest {
     void bulkDeleteReturnsSuccess() throws Exception {
         doNothing().when(service).deleteBulk(anyList());
         String payload = "[\"" + UUID.randomUUID() + "\"]";
-        mockMvc.perform(delete("/user/permission/_bulk")
+        mockMvc.perform(delete("/user/permission/bulk")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- rename permission bulk create and delete endpoints to `/bulk`
- align controller tests with new `bulk` path

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ea1f4f6d8832da39d80d54c135a5c