### PR TITLE
Use MockitoExtension for user-service controller tests

### DIFF
--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -3,16 +3,20 @@ package morning.com.services.user.controller;
 import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.exception.GlobalExceptionHandler;
 import morning.com.services.user.service.PermissionService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.Instant;
 import java.util.List;
@@ -24,14 +28,23 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(PermissionController.class)
+@ExtendWith(MockitoExtension.class)
 class PermissionControllerTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Mock
     private PermissionService service;
+
+    @InjectMocks
+    private PermissionController controller;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
 
     @Test
     void listReturnsPermissions() throws Exception {

--- a/user-service/src/test/java/morning/com/services/user/controller/RoleControllerValidationTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/RoleControllerValidationTest.java
@@ -2,27 +2,40 @@ package morning.com.services.user.controller;
 
 import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.exception.GlobalExceptionHandler;
 import morning.com.services.user.service.RoleService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(RoleController.class)
+@ExtendWith(MockitoExtension.class)
 class RoleControllerValidationTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Mock
     private RoleService service;
+
+    @InjectMocks
+    private RoleController controller;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
 
     @Test
     void createWhenInvalidFieldsReturnsErrors() throws Exception {


### PR DESCRIPTION
## Summary
- Replace `@WebMvcTest` with Mockito-based standalone MockMvc in controller tests
- Apply `MockitoExtension` with manual MockMvc setup using `GlobalExceptionHandler`

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689eabb2432c832d9183711faff57999