### PR TITLE
Use JPA Specification for permission search

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -2,21 +2,18 @@ package morning.com.services.user.repository;
 
 import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.entity.Permission;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface PermissionRepository extends JpaRepository<Permission, UUID> {
+public interface PermissionRepository extends JpaRepository<Permission, UUID>,
+        JpaSpecificationExecutor<Permission> {
 
     @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
     List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
 
     boolean existsByCode(String code);
-
-    Page<Permission> findByCodeContainingIgnoreCaseOrSectionContainingIgnoreCaseOrLabelContainingIgnoreCase(
-            String code, String section, String label, Pageable pageable);
 }

--- a/user-service/src/test/java/morning/com/services/user/service/PermissionServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/PermissionServiceTest.java
@@ -1,0 +1,52 @@
+package morning.com.services.user.service;
+
+import morning.com.services.user.mapper.PermissionMapper;
+import morning.com.services.user.repository.PermissionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PermissionServiceTest {
+
+    @Mock
+    private PermissionRepository repository;
+
+    @Mock
+    private PermissionMapper mapper;
+
+    @InjectMocks
+    private PermissionService service;
+
+    @Test
+    void searchWithQueryUsesSpecification() {
+        Pageable pageable = PageRequest.of(0, 10);
+        when(repository.findAll(any(Specification.class), eq(pageable))).thenReturn(Page.empty());
+
+        service.search("test", pageable);
+
+        verify(repository).findAll(any(Specification.class), eq(pageable));
+    }
+
+    @Test
+    void searchWithoutQueryUsesFindAll() {
+        Pageable pageable = PageRequest.of(0, 10);
+        when(repository.findAll(pageable)).thenReturn(Page.empty());
+
+        service.search(null, pageable);
+
+        verify(repository).findAll(pageable);
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor PermissionRepository to support Specifications
- search permissions using Specification filtering
- cover PermissionService search scenarios with tests

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689eb1d4d100832d83c7a513202f5839