### PR TITLE
feat: add permission list filtering with specifications

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -35,11 +35,14 @@ public class PermissionController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "asc") String direction,
-            @RequestParam(required = false) String search) {
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String section,
+            @RequestParam(required = false) String code) {
         Sort sort = direction.equalsIgnoreCase("desc")
                 ? Sort.by(sortBy).descending()
                 : Sort.by(sortBy).ascending();
-        Page<PermissionResponse> result = service.search(search, PageRequest.of(Math.max(page - 1, 0), size, sort));
+        Page<PermissionResponse> result = service.search(search, section, code,
+                PageRequest.of(Math.max(page - 1, 0), size, sort));
         return ApiResponse.success(MessageKeys.SUCCESS, result);
     }
 

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -2,21 +2,17 @@ package morning.com.services.user.repository;
 
 import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.entity.Permission;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface PermissionRepository extends JpaRepository<Permission, UUID> {
+public interface PermissionRepository extends JpaRepository<Permission, UUID>, JpaSpecificationExecutor<Permission> {
 
     @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
     List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
 
     boolean existsByCode(String code);
-
-    Page<Permission> findByCodeContainingIgnoreCaseOrSectionContainingIgnoreCaseOrLabelContainingIgnoreCase(
-            String code, String section, String label, Pageable pageable);
 }

--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionSpecification.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionSpecification.java
@@ -1,0 +1,25 @@
+package morning.com.services.user.repository;
+
+import morning.com.services.user.entity.Permission;
+import org.springframework.data.jpa.domain.Specification;
+
+public class PermissionSpecification {
+    public static Specification<Permission> searchInAll(String term) {
+        return (root, query, cb) -> {
+            String like = "%" + term.toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("code")), like),
+                    cb.like(cb.lower(root.get("section")), like),
+                    cb.like(cb.lower(root.get("label")), like)
+            );
+        };
+    }
+
+    public static Specification<Permission> sectionContains(String section) {
+        return (root, query, cb) -> cb.like(cb.lower(root.get("section")), "%" + section.toLowerCase() + "%");
+    }
+
+    public static Specification<Permission> codeEquals(String code) {
+        return (root, query, cb) -> cb.equal(cb.lower(root.get("code")), code.toLowerCase());
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -7,6 +7,8 @@ import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.entity.Permission;
 import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
+import morning.com.services.user.repository.PermissionSpecification;
+import org.springframework.data.jpa.domain.Specification;
 import morning.com.services.user.exception.FieldValidationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -50,14 +52,18 @@ public class PermissionService {
         return repository.findById(id);
     }
 
-    public Page<PermissionResponse> search(String search, Pageable pageable) {
-        Page<Permission> page;
+    public Page<PermissionResponse> search(String search, String section, String code, Pageable pageable) {
+        Specification<Permission> spec = Specification.where(null);
         if (search != null && !search.isBlank()) {
-            page = repository.findByCodeContainingIgnoreCaseOrSectionContainingIgnoreCaseOrLabelContainingIgnoreCase(
-                    search, search, search, pageable);
-        } else {
-            page = repository.findAll(pageable);
+            spec = spec.and(PermissionSpecification.searchInAll(search));
         }
+        if (section != null && !section.isBlank()) {
+            spec = spec.and(PermissionSpecification.sectionContains(section));
+        }
+        if (code != null && !code.isBlank()) {
+            spec = spec.and(PermissionSpecification.codeEquals(code));
+        }
+        Page<Permission> page = repository.findAll(spec, pageable);
         return page.map(mapper::toResponse);
     }
 

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -50,9 +50,12 @@ class PermissionControllerTest {
     void listReturnsPermissions() throws Exception {
         PermissionResponse resp = new PermissionResponse(UUID.randomUUID(), "CODE", "SEC", "LBL", Instant.now(), Instant.now());
         Page<PermissionResponse> page = new PageImpl<>(List.of(resp), PageRequest.of(0, 10), 1);
-        when(service.search(eq("test"), any())).thenReturn(page);
+        when(service.search(eq("test"), eq("SEC"), eq("CODE"), any())).thenReturn(page);
 
-        mockMvc.perform(get("/user/permission").param("search", "test"))
+        mockMvc.perform(get("/user/permission")
+                        .param("search", "test")
+                        .param("section", "SEC")
+                        .param("code", "CODE"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].id").value(resp.id().toString()));
     }


### PR DESCRIPTION
## Summary
- support listing permissions with search, section and code filters
- build dynamic JPA specifications for optional filters
- cover new filtering options in controller tests

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM for spring-boot-starter-parent due to network)*

------
https://chatgpt.com/codex/tasks/task_e_689eb5b82200832dbecad48eef1ef7f4