### PR TITLE
Refactor permission specifications

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -7,7 +7,7 @@ import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.entity.Permission;
 import morning.com.services.user.mapper.PermissionMapper;
 import morning.com.services.user.repository.PermissionRepository;
-import morning.com.services.user.repository.PermissionSpecification;
+import morning.com.services.user.specification.PermissionSpecification;
 import org.springframework.data.jpa.domain.Specification;
 import morning.com.services.user.exception.FieldValidationException;
 import org.springframework.data.domain.Page;
@@ -53,7 +53,7 @@ public class PermissionService {
     }
 
     public Page<PermissionResponse> search(String search, String section, String code, Pageable pageable) {
-        Specification<Permission> spec = Specification.where(null);
+        Specification<Permission> spec = Specification.allOf();
         if (search != null && !search.isBlank()) {
             spec = spec.and(PermissionSpecification.searchInAll(search));
         }

--- a/user-service/src/main/java/morning/com/services/user/specification/PermissionSpecification.java
+++ b/user-service/src/main/java/morning/com/services/user/specification/PermissionSpecification.java
@@ -1,4 +1,4 @@
-package morning.com.services.user.repository;
+package morning.com.services.user.specification;
 
 import morning.com.services.user.entity.Permission;
 import org.springframework.data.jpa.domain.Specification;


### PR DESCRIPTION
## Summary
- avoid deprecated `Specification.where` call in PermissionService
- move PermissionSpecification into dedicated specification package

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ebae45d1c832daa56608d31585908