### PR TITLE
Use derived query for permissions

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/PermissionRepository.java
@@ -4,15 +4,13 @@ import morning.com.services.user.dto.PermissionDTO;
 import morning.com.services.user.entity.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface PermissionRepository extends JpaRepository<Permission, UUID>, JpaSpecificationExecutor<Permission> {
 
-    @Query("select new morning.com.services.user.dto.PermissionDTO(p.id, p.code, p.section, p.label) from Permission p order by p.section asc, p.label asc")
-    List<PermissionDTO> findAllProjectedByOrderBySectionAscLabelAsc();
+    List<PermissionDTO> findAllByOrderBySectionAscLabelAsc();
 
     boolean existsByCode(String code);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -60,7 +60,7 @@ public class RoleService {
 
     public MatrixResponse getMatrix() {
         List<RoleDTO> roles = roleRepository.findAllProjectedBy();
-        List<PermissionDTO> permissions = permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc();
+        List<PermissionDTO> permissions = permissionRepository.findAllByOrderBySectionAscLabelAsc();
         List<RolePermissionEdge> edges = rolePermissionRepository.findAllRolePermissionEdges().stream()
                 .map(e -> new RolePermissionEdge(e.getRoleId(), e.getPermissionId()))
                 .toList();

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -83,7 +83,7 @@ class RoleServiceTest {
         when(edge.getPermissionId()).thenReturn(perm.id());
 
         when(roleRepository.findAllProjectedBy()).thenReturn(List.of(role));
-        when(permissionRepository.findAllProjectedByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
+        when(permissionRepository.findAllByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
         when(rolePermissionRepository.findAllRolePermissionEdges()).thenReturn(List.of(edge));
 
         MatrixResponse matrix = service.getMatrix();
@@ -93,7 +93,7 @@ class RoleServiceTest {
         assertEquals(List.of(new RolePermissionEdge(role.id(), perm.id())), matrix.grants());
 
         verify(roleRepository).findAllProjectedBy();
-        verify(permissionRepository).findAllProjectedByOrderBySectionAscLabelAsc();
+        verify(permissionRepository).findAllByOrderBySectionAscLabelAsc();
         verify(rolePermissionRepository).findAllRolePermissionEdges();
     }
 }


### PR DESCRIPTION
## Summary
- Replace JPQL `@Query` in `PermissionRepository` with derived query method
- Adjust `RoleService` and its tests to call the new repository method

## Testing
- `mvn -pl user-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689ed6e39fa4832d8509218f3f1dede4