### PR TITLE
refactor: eliminate raw queries in role repositories

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
@@ -3,15 +3,13 @@ package morning.com.services.user.repository;
 import morning.com.services.user.dto.RoleDTO;
 import morning.com.services.user.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface RoleRepository extends JpaRepository<Role, UUID> {
 
-    @Query("select new morning.com.services.user.dto.RoleDTO(r.id, r.name) from Role r order by r.name")
-    List<RoleDTO> findAllProjectedBy();
+    List<RoleDTO> findAllByOrderByName();
 
     boolean existsByName(String name);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -59,9 +59,9 @@ public class RoleService {
     }
 
     public MatrixResponse getMatrix() {
-        List<RoleDTO> roles = roleRepository.findAllProjectedBy();
+        List<RoleDTO> roles = roleRepository.findAllByOrderByName();
         List<PermissionDTO> permissions = permissionRepository.findAllByOrderBySectionAscLabelAsc();
-        List<RolePermissionEdge> edges = rolePermissionRepository.findAllRolePermissionEdges().stream()
+        List<RolePermissionEdge> edges = rolePermissionRepository.findAllProjectedBy().stream()
                 .map(e -> new RolePermissionEdge(e.getRoleId(), e.getPermissionId()))
                 .toList();
         return new MatrixResponse(roles, permissions, edges);

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -82,9 +82,9 @@ class RoleServiceTest {
         when(edge.getRoleId()).thenReturn(role.id());
         when(edge.getPermissionId()).thenReturn(perm.id());
 
-        when(roleRepository.findAllProjectedBy()).thenReturn(List.of(role));
+        when(roleRepository.findAllByOrderByName()).thenReturn(List.of(role));
         when(permissionRepository.findAllByOrderBySectionAscLabelAsc()).thenReturn(List.of(perm));
-        when(rolePermissionRepository.findAllRolePermissionEdges()).thenReturn(List.of(edge));
+        when(rolePermissionRepository.findAllProjectedBy()).thenReturn(List.of(edge));
 
         MatrixResponse matrix = service.getMatrix();
 
@@ -92,9 +92,9 @@ class RoleServiceTest {
         assertEquals(List.of(perm), matrix.permissions());
         assertEquals(List.of(new RolePermissionEdge(role.id(), perm.id())), matrix.grants());
 
-        verify(roleRepository).findAllProjectedBy();
+        verify(roleRepository).findAllByOrderByName();
         verify(permissionRepository).findAllByOrderBySectionAscLabelAsc();
-        verify(rolePermissionRepository).findAllRolePermissionEdges();
+        verify(rolePermissionRepository).findAllProjectedBy();
     }
 }
 


### PR DESCRIPTION
## Summary
- replace native queries in `RolePermissionRepository` with JPA `save` and `deleteById` helpers
- use derived query in `RoleRepository` to fetch role projections ordered by name
- adjust service and tests to new repository methods

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ed9d3d6ac832d824ea1ac37c8e30c