### PR TITLE
feat: use minimal page wrapper for permissions list

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -7,7 +7,7 @@ import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.dto.PermissionCreateRequest;
 import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.dto.PermissionUpdateRequest;
-import morning.com.services.user.dto.PageResponse;
+import morning.com.services.user.dto.PageResult;
 import morning.com.services.user.service.PermissionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,7 +31,7 @@ public class PermissionController {
 
     @GetMapping
     @Operation(summary = "List permissions")
-    public ResponseEntity<ApiResponse<PageResponse<PermissionResponse>>> list(
+    public ResponseEntity<ApiResponse<PageResult<PermissionResponse>>> list(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
@@ -44,7 +44,7 @@ public class PermissionController {
                 : Sort.by(sortBy).ascending();
         Page<PermissionResponse> result = service.search(search, section, code,
                 PageRequest.of(Math.max(page - 1, 0), size, sort));
-        return ApiResponse.success(MessageKeys.SUCCESS, PageResponse.from(result));
+        return ApiResponse.success(MessageKeys.SUCCESS, PageResult.from(result));
     }
 
     @PostMapping

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -7,6 +7,7 @@ import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.dto.PermissionCreateRequest;
 import morning.com.services.user.dto.PermissionResponse;
 import morning.com.services.user.dto.PermissionUpdateRequest;
+import morning.com.services.user.dto.PageResponse;
 import morning.com.services.user.service.PermissionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,7 +31,7 @@ public class PermissionController {
 
     @GetMapping
     @Operation(summary = "List permissions")
-    public ResponseEntity<ApiResponse<Page<PermissionResponse>>> list(
+    public ResponseEntity<ApiResponse<PageResponse<PermissionResponse>>> list(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
@@ -43,7 +44,7 @@ public class PermissionController {
                 : Sort.by(sortBy).ascending();
         Page<PermissionResponse> result = service.search(search, section, code,
                 PageRequest.of(Math.max(page - 1, 0), size, sort));
-        return ApiResponse.success(MessageKeys.SUCCESS, result);
+        return ApiResponse.success(MessageKeys.SUCCESS, PageResponse.from(result));
     }
 
     @PostMapping

--- a/user-service/src/main/java/morning/com/services/user/dto/PageResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PageResponse.java
@@ -1,0 +1,28 @@
+package morning.com.services.user.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * Minimal wrapper for paginated responses.
+ */
+public record PageResponse<T>(
+        List<T> items,
+        int page,
+        int size,
+        long total,
+        int totalPages,
+        boolean hasNext) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/dto/PageResult.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/PageResult.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Minimal wrapper for paginated responses.
  */
-public record PageResponse<T>(
+public record PageResult<T>(
         List<T> items,
         int page,
         int size,
@@ -15,8 +15,8 @@ public record PageResponse<T>(
         int totalPages,
         boolean hasNext) {
 
-    public static <T> PageResponse<T> from(Page<T> page) {
-        return new PageResponse<>(
+    public static <T> PageResult<T> from(Page<T> page) {
+        return new PageResult<>(
                 page.getContent(),
                 page.getNumber() + 1,
                 page.getSize(),

--- a/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/PermissionControllerTest.java
@@ -57,7 +57,12 @@ class PermissionControllerTest {
                         .param("section", "SEC")
                         .param("code", "CODE"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content[0].id").value(resp.id().toString()));
+                .andExpect(jsonPath("$.data.items[0].id").value(resp.id().toString()))
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.total").value(1))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add generic `PageResponse` record to expose minimal pagination fields
- update permission controller to return wrapped page data
- adapt tests for new pagination format

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM for spring-boot-subscription-platform: The following artifacts could not be resolved ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ee2aba250832d853c03dbd3e1869b