### PR TITLE
Use exact match for permission section filtering

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/PermissionService.java
@@ -58,7 +58,7 @@ public class PermissionService {
             spec = spec.and(PermissionSpecification.searchInAll(search));
         }
         if (section != null && !section.isBlank()) {
-            spec = spec.and(PermissionSpecification.sectionContains(section));
+            spec = spec.and(PermissionSpecification.sectionEquals(section));
         }
         if (code != null && !code.isBlank()) {
             spec = spec.and(PermissionSpecification.codeEquals(code));

--- a/user-service/src/main/java/morning/com/services/user/specification/PermissionSpecification.java
+++ b/user-service/src/main/java/morning/com/services/user/specification/PermissionSpecification.java
@@ -15,8 +15,8 @@ public class PermissionSpecification {
         };
     }
 
-    public static Specification<Permission> sectionContains(String section) {
-        return (root, query, cb) -> cb.like(cb.lower(root.get("section")), "%" + section.toLowerCase() + "%");
+    public static Specification<Permission> sectionEquals(String section) {
+        return (root, query, cb) -> cb.equal(cb.lower(root.get("section")), section.toLowerCase());
     }
 
     public static Specification<Permission> codeEquals(String code) {


### PR DESCRIPTION
## Summary
- use strict equality for permission section filtering

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_689ee6660b80832d948f3cd909ad0a7a