### PR TITLE
feat: add role code and CRUD endpoints

### DIFF
--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -1,8 +1,9 @@
 package morning.com.services.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import morning.com.services.user.dto.*;
 import morning.com.services.user.service.RoleService;
-import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +29,23 @@ public class RoleController {
                 saved,
                 "/role/" + saved.id()
         );
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update existing role")
+    public ResponseEntity<ApiResponse<RoleResponse>> update(@PathVariable UUID id,
+                                                            @Validated @RequestBody RoleUpdateRequest request) {
+        return service.update(id, request)
+                .map(resp -> ApiResponse.success(MessageKeys.SUCCESS, resp))
+                .orElseGet(() -> ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.ROLE_NOT_FOUND));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete role")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable UUID id) {
+        return service.delete(id)
+                ? ApiResponse.success(MessageKeys.SUCCESS)
+                : ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.ROLE_NOT_FOUND);
     }
 
     @GetMapping("/acl-matrix")

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleDTO.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleDTO.java
@@ -2,4 +2,4 @@ package morning.com.services.user.dto;
 
 import java.util.UUID;
 
-public record RoleDTO(UUID id, String name) {}
+public record RoleDTO(UUID id, String code, String name) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleResponse.java
@@ -7,6 +7,7 @@ import java.util.UUID;
  */
 public record RoleResponse(
         UUID id,
+        String code,
         String name,
         String description
 ) {}

--- a/user-service/src/main/java/morning/com/services/user/dto/RoleUpdateRequest.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/RoleUpdateRequest.java
@@ -4,11 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 /**
- * DTO for creating a Role.
+ * DTO for updating an existing Role.
+ * Identifier is provided via the path variable.
  */
-public record RoleCreateRequest(
-        @NotBlank @Size(max = 100) String code,
+public record RoleUpdateRequest(
         @NotBlank @Size(max = 100) String name,
         @Size(max = 255) String description
-) {}
+) {
+}
 

--- a/user-service/src/main/java/morning/com/services/user/entity/Role.java
+++ b/user-service/src/main/java/morning/com/services/user/entity/Role.java
@@ -33,6 +33,9 @@ public class Role {
     private UUID id;
 
     @Column(nullable = false, unique = true, length = 100)
+    private String code;
+
+    @Column(nullable = false, unique = true, length = 100)
     private String name;
 
     @Column(length = 255)

--- a/user-service/src/main/java/morning/com/services/user/mapper/RoleMapper.java
+++ b/user-service/src/main/java/morning/com/services/user/mapper/RoleMapper.java
@@ -2,9 +2,11 @@ package morning.com.services.user.mapper;
 
 import morning.com.services.user.dto.RoleCreateRequest;
 import morning.com.services.user.dto.RoleResponse;
+import morning.com.services.user.dto.RoleUpdateRequest;
 import morning.com.services.user.entity.Role;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 /**
  * MapStruct mapper for converting between Role entities and DTOs.
@@ -17,6 +19,13 @@ public interface RoleMapper {
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     Role toEntity(RoleCreateRequest request);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "code", ignore = true)
+    @Mapping(target = "permissions", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    void update(@MappingTarget Role role, RoleUpdateRequest request);
 
     RoleResponse toResponse(Role role);
 }

--- a/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
+++ b/user-service/src/main/java/morning/com/services/user/repository/RoleRepository.java
@@ -12,4 +12,6 @@ public interface RoleRepository extends JpaRepository<Role, UUID> {
     List<RoleDTO> findAllByOrderByName();
 
     boolean existsByName(String name);
+
+    boolean existsByCode(String code);
 }

--- a/user-service/src/main/java/morning/com/services/user/service/RoleService.java
+++ b/user-service/src/main/java/morning/com/services/user/service/RoleService.java
@@ -38,6 +38,9 @@ public class RoleService {
 
     @Transactional
     public RoleResponse add(RoleCreateRequest request) {
+        if (roleRepository.existsByCode(request.code())) {
+            throw new FieldValidationException("code", "already.exists");
+        }
         if (roleRepository.existsByName(request.name())) {
             throw new FieldValidationException("name", "already.exists");
         }
@@ -48,6 +51,25 @@ public class RoleService {
 
     public Optional<Role> findById(UUID id) {
         return roleRepository.findById(id);
+    }
+
+    @Transactional
+    public Optional<RoleResponse> update(UUID id, RoleUpdateRequest request) {
+        return roleRepository.findById(id)
+                .map(entity -> {
+                    mapper.update(entity, request);
+                    Role updated = roleRepository.save(entity);
+                    return mapper.toResponse(updated);
+                });
+    }
+
+    @Transactional
+    public boolean delete(UUID id) {
+        if (!roleRepository.existsById(id)) {
+            return false;
+        }
+        roleRepository.deleteById(id);
+        return true;
     }
 
     @Transactional

--- a/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
+++ b/user-service/src/main/resources/db/migration/V2__add_roles_and_permissions.sql
@@ -2,9 +2,11 @@
 CREATE TABLE roles
 (
     id   BINARY(16) NOT NULL,
+    code VARCHAR(100) NOT NULL,
     name VARCHAR(100) NOT NULL,
 
     CONSTRAINT pk_roles PRIMARY KEY (id),
+    CONSTRAINT ux_roles_code UNIQUE (code),
     CONSTRAINT ux_roles_name UNIQUE (name)
 ) ENGINE=InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/user-service/src/main/resources/db/migration/V4__seed_roles_permissions.sql
+++ b/user-service/src/main/resources/db/migration/V4__seed_roles_permissions.sql
@@ -1,10 +1,10 @@
 -- Seed default roles
-INSERT INTO roles (id, name, description) VALUES
-  (UUID_TO_BIN('c3908054-dc02-43c6-8eca-969b7da54ea4'), 'Super Admin', 'Full platform access'),
-  (UUID_TO_BIN('7e6c7b80-46bd-48c4-bc05-6e8e78f06116'), 'Admin', 'Manage subscriptions and customers'),
-  (UUID_TO_BIN('4d50cf00-f990-4172-bd30-92595e2f4a02'), 'Merchant', 'Owns and manages sites, products, services'),
-  (UUID_TO_BIN('d7317200-5f5c-47a9-aa5f-023dd9fccd3a'), 'Marketing', 'Promote via referral/invite codes'),
-  (UUID_TO_BIN('09b2b833-3303-4b45-848a-883b5e66faa0'), 'Assists', 'Assists Merchant in site/product/category management');
+INSERT INTO roles (id, code, name, description) VALUES
+  (UUID_TO_BIN('c3908054-dc02-43c6-8eca-969b7da54ea4'), 'super_admin', 'Super Admin', 'Full platform access'),
+  (UUID_TO_BIN('7e6c7b80-46bd-48c4-bc05-6e8e78f06116'), 'admin', 'Admin', 'Manage subscriptions and customers'),
+  (UUID_TO_BIN('4d50cf00-f990-4172-bd30-92595e2f4a02'), 'merchant', 'Merchant', 'Owns and manages sites, products, services'),
+  (UUID_TO_BIN('d7317200-5f5c-47a9-aa5f-023dd9fccd3a'), 'marketing', 'Marketing', 'Promote via referral/invite codes'),
+  (UUID_TO_BIN('09b2b833-3303-4b45-848a-883b5e66faa0'), 'assists', 'Assists', 'Assists Merchant in site/product/category management');
 
 -- Seed permissions
 INSERT INTO permissions (id, code, section, label) VALUES

--- a/user-service/src/test/java/morning/com/services/user/controller/RoleControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/RoleControllerTest.java
@@ -39,19 +39,19 @@ class RoleControllerTest {
 
     @Test
     void createWhenInvalidFieldsReturnsErrors() throws Exception {
-        String payload = "{\"name\":\"\",\"description\":\"\"}";
+        String payload = "{\"code\":\"\",\"name\":\"\",\"description\":\"\"}";
         mockMvc.perform(post("/user/role")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.data.name").exists());
+                .andExpect(jsonPath("$.data.code").exists());
     }
 
     @Test
     void createWhenDuplicateNameReturnsFieldError() throws Exception {
         when(service.add(any())).thenThrow(new FieldValidationException("name", "already exists"));
-        String payload = "{\"name\":\"admin\",\"description\":\"\"}";
+        String payload = "{\"code\":\"admin\",\"name\":\"admin\",\"description\":\"\"}";
         mockMvc.perform(post("/user/role")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))

--- a/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
+++ b/user-service/src/test/java/morning/com/services/user/service/RoleServiceTest.java
@@ -50,12 +50,25 @@ class RoleServiceTest {
 
     @Test
     void addWhenNameExistsThrowsFieldValidationException() {
-        RoleCreateRequest request = new RoleCreateRequest("admin", null);
-        when(roleRepository.existsByName("admin")).thenReturn(true);
+        RoleCreateRequest request = new RoleCreateRequest("admin", "Admin", null);
+        when(roleRepository.existsByCode("admin")).thenReturn(false);
+        when(roleRepository.existsByName("Admin")).thenReturn(true);
 
         assertThrows(FieldValidationException.class, () -> service.add(request));
 
-        verify(roleRepository).existsByName("admin");
+        verify(roleRepository).existsByCode("admin");
+        verify(roleRepository).existsByName("Admin");
+        verifyNoMoreInteractions(roleRepository);
+    }
+
+    @Test
+    void addWhenCodeExistsThrowsFieldValidationException() {
+        RoleCreateRequest request = new RoleCreateRequest("admin", "Admin", null);
+        when(roleRepository.existsByCode("admin")).thenReturn(true);
+
+        assertThrows(FieldValidationException.class, () -> service.add(request));
+
+        verify(roleRepository).existsByCode("admin");
         verifyNoMoreInteractions(roleRepository);
     }
 
@@ -75,7 +88,7 @@ class RoleServiceTest {
 
     @Test
     void getMatrixCombinesDataFromRepositories() {
-        RoleDTO role = new RoleDTO(UUID.randomUUID(), "admin");
+        RoleDTO role = new RoleDTO(UUID.randomUUID(), "admin", "Admin");
         PermissionDTO perm = new PermissionDTO(UUID.randomUUID(), "code", "sec", "label");
 
         RolePermissionRepository.RolePermissionEdgeView edge = mock(RolePermissionRepository.RolePermissionEdgeView.class);


### PR DESCRIPTION
## Summary
- add `code` column to roles with unique index and seed data
- support creating, updating and deleting roles via new DTOs, service methods and controller endpoints

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ef2fce9a8832da52ace82758a24ef