### PR TITLE
Refactor ApiResponse to use numeric codes

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/ApiResponse.java
@@ -1,40 +1,35 @@
 package morning.com.services.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 /**
- * Standard API wrapper: { status: success|error, messageKey, data }
+ * Standard API wrapper: { code: 0|-1, messageKey, data }
  * Includes minimal static helpers for common HTTP responses.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(Status status, String messageKey, T data) {
+public record ApiResponse<T>(int code, String messageKey, T data) {
 
-    public enum Status {
-        SUCCESS("success"), ERROR("error");
-        private final String json;
-        Status(String json) { this.json = json; }
-        @JsonValue public String json() { return json; }
-    }
+    public static final int SUCCESS = 0;
+    public static final int ERROR = -1;
 
     // ---- Factory helpers producing ResponseEntity<ApiResponse<T>> ----
     public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey, T data) {
-        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+        return ResponseEntity.ok(new ApiResponse<>(SUCCESS, messageKey, data));
     }
     public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey) {
-        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, null));
+        return ResponseEntity.ok(new ApiResponse<>(SUCCESS, messageKey, null));
     }
     public static <T> ResponseEntity<ApiResponse<T>> created(String messageKey, T data, String location) {
         return ResponseEntity.created(java.net.URI.create(location))
-                .body(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+                .body(new ApiResponse<>(SUCCESS, messageKey, data));
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey) {
-        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, null));
+        return ResponseEntity.status(status).body(new ApiResponse<>(ERROR, messageKey, null));
     }
     public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey, T data) {
-        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, data));
+        return ResponseEntity.status(status).body(new ApiResponse<>(ERROR, messageKey, data));
     }
 }

--- a/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/morning/com/services/auth/controller/AuthControllerTest.java
@@ -18,8 +18,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.util.UUID;
 
-import static morning.com.services.auth.dto.ApiResponse.Status.ERROR;
-import static morning.com.services.auth.dto.ApiResponse.Status.SUCCESS;
+import static morning.com.services.auth.dto.ApiResponse.ERROR;
+import static morning.com.services.auth.dto.ApiResponse.SUCCESS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -47,7 +47,7 @@ class AuthControllerTest {
 
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(SUCCESS, body.status());
+        assertEquals(SUCCESS, body.code());
         assertEquals(MessageKeys.USER_REGISTERED, body.messageKey());
         verify(userService).register("user", "password");
     }
@@ -63,7 +63,7 @@ class AuthControllerTest {
 
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ERROR, body.status());
+        assertEquals(ERROR, body.code());
         assertEquals(MessageKeys.USERNAME_EXISTS, body.messageKey());
     }
 
@@ -87,7 +87,7 @@ class AuthControllerTest {
 
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(SUCCESS, body.status());
+        assertEquals(SUCCESS, body.code());
         assertEquals(MessageKeys.SUCCESS, body.messageKey());
         assertNotNull(body.data());
         assertEquals("token123", body.data().token());
@@ -106,7 +106,7 @@ class AuthControllerTest {
 
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ERROR, body.status());
+        assertEquals(ERROR, body.code());
         assertEquals(MessageKeys.INVALID_CREDENTIALS, body.messageKey());
         assertNull(body.data());
     }
@@ -134,7 +134,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(SUCCESS, body.status());
+        assertEquals(SUCCESS, body.code());
         assertEquals("token2", body.data().token());
         assertEquals("newRef", body.data().refreshToken());
     }
@@ -148,7 +148,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
         ApiResponse<AuthResponse> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ERROR, body.status());
+        assertEquals(ERROR, body.code());
         assertEquals(MessageKeys.INVALID_CREDENTIALS, body.messageKey());
     }
 
@@ -170,7 +170,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.UNAUTHORIZED, second.getStatusCode());
         ApiResponse<AuthResponse> body = second.getBody();
         assertNotNull(body);
-        assertEquals(ERROR, body.status());
+        assertEquals(ERROR, body.code());
     }
 
     @Test
@@ -183,7 +183,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(SUCCESS, body.status());
+        assertEquals(SUCCESS, body.code());
         assertEquals(MessageKeys.PASSWORD_CHANGED, body.messageKey());
     }
 
@@ -197,7 +197,7 @@ class AuthControllerTest {
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
         ApiResponse<Void> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ERROR, body.status());
+        assertEquals(ERROR, body.code());
         assertEquals(MessageKeys.INVALID_CREDENTIALS, body.messageKey());
     }
 }

--- a/user-service/src/main/java/morning/com/services/user/dto/ApiResponse.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/ApiResponse.java
@@ -1,7 +1,6 @@
 package morning.com.services.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -11,35 +10,31 @@ import org.springframework.http.ResponseEntity;
  * consistent payloads across services.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(Status status, String messageKey, T data) {
+public record ApiResponse<T>(int code, String messageKey, T data) {
 
-    public enum Status {
-        SUCCESS("success"), ERROR("error");
-        private final String json;
-        Status(String json) { this.json = json; }
-        @JsonValue public String json() { return json; }
-    }
+    public static final int SUCCESS = 0;
+    public static final int ERROR = -1;
 
     // ---- Factory helpers producing ResponseEntity<ApiResponse<T>> ----
     public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey, T data) {
-        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+        return ResponseEntity.ok(new ApiResponse<>(SUCCESS, messageKey, data));
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> success(String messageKey) {
-        return ResponseEntity.ok(new ApiResponse<>(Status.SUCCESS, messageKey, null));
+        return ResponseEntity.ok(new ApiResponse<>(SUCCESS, messageKey, null));
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> created(String messageKey, T data, String location) {
         return ResponseEntity.created(java.net.URI.create(location))
-                .body(new ApiResponse<>(Status.SUCCESS, messageKey, data));
+                .body(new ApiResponse<>(SUCCESS, messageKey, data));
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey) {
-        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, null));
+        return ResponseEntity.status(status).body(new ApiResponse<>(ERROR, messageKey, null));
     }
 
     public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String messageKey, T data) {
-        return ResponseEntity.status(status).body(new ApiResponse<>(Status.ERROR, messageKey, data));
+        return ResponseEntity.status(status).body(new ApiResponse<>(ERROR, messageKey, data));
     }
 }
 

--- a/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/UserProfileControllerTest.java
@@ -42,7 +42,7 @@ class UserProfileControllerTest {
         assertEquals(201, result.getStatusCodeValue());
         ApiResponse<UserProfile> body = result.getBody();
         assertNotNull(body);
-        assertEquals(ApiResponse.Status.SUCCESS, body.status());
+        assertEquals(ApiResponse.SUCCESS, body.code());
         assertEquals(MessageKeys.PROFILE_CREATED, body.messageKey());
         assertSame(saved, body.data());
         verify(service).add(input);
@@ -59,7 +59,7 @@ class UserProfileControllerTest {
         assertEquals(200, response.getStatusCodeValue());
         ApiResponse<UserProfile> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ApiResponse.Status.SUCCESS, body.status());
+        assertEquals(ApiResponse.SUCCESS, body.code());
         assertEquals(MessageKeys.SUCCESS, body.messageKey());
         assertSame(saved, body.data());
         verify(service).findById(id);
@@ -75,7 +75,7 @@ class UserProfileControllerTest {
         assertEquals(404, response.getStatusCodeValue());
         ApiResponse<UserProfile> body = response.getBody();
         assertNotNull(body);
-        assertEquals(ApiResponse.Status.ERROR, body.status());
+        assertEquals(ApiResponse.ERROR, body.code());
         assertEquals(MessageKeys.PROFILE_NOT_FOUND, body.messageKey());
         assertNull(body.data());
         verify(service).findById(missing);


### PR DESCRIPTION
## Summary
- replace ApiResponse `Status` enum with numeric `code` across services
- update tests to assert numeric codes

## Testing
- `mvn -q -pl auth-service,user-service test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f08fcd92c832da0c773d23c9c2eb6