### PR TITLE
feat: include user info in auth response

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/AuthResponse.java
@@ -1,12 +1,18 @@
 package morning.com.services.auth.dto;
 
+import java.util.UUID;
+
 public record AuthResponse(
-        String token,
+        UUID id,
+        String username,
+        String email,
+        String locale,
+        String accessToken,
         String tokenType,
         long expiresAt,
         String refreshToken
 ) {
-    public AuthResponse(String token, long expiresAt, String refreshToken) {
-        this(token, "Bearer", expiresAt, refreshToken);
+    public AuthResponse(UUID id, String username, String email, String locale, String accessToken, long expiresAt, String refreshToken) {
+        this(id, username, email, locale, accessToken, "Bearer", expiresAt, refreshToken);
     }
 }


### PR DESCRIPTION
## Summary
- rename `token` to `accessToken` and embed user id/username/email/locale in `AuthResponse`
- expose user info on login and token refresh
- adjust unit tests for updated auth response

## Testing
- `mvn -q -pl auth-service test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0dbcdce4832d95cd1cf984eb0c91