### PR TITLE
Secure user-service with OAuth2 resource server

### DIFF
--- a/config-service/src/main/resources/config/user-service-docker.yml
+++ b/config-service/src/main/resources/config/user-service-docker.yml
@@ -32,6 +32,11 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://auth-service:9000
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/user-service.yml
+++ b/config-service/src/main/resources/config/user-service.yml
@@ -38,6 +38,11 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://auth-service:9000
 
 management:
   tracing:

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>

--- a/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package morning.com.services.user.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**", "/v3/api-docs/**", "/swagger-ui/**", "/user/public/**").permitAll()
+                        .requestMatchers("/user/api/**").authenticated()
+                        .anyRequest().denyAll()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
+                );
+        return http.build();
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder() {
+        NimbusJwtDecoder decoder = JwtDecoders.fromIssuerLocation(issuerUri);
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
+        OAuth2TokenValidator<Jwt> audience = new AudienceValidator("user-service");
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(withIssuer, audience));
+        return decoder;
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter gac = new JwtGrantedAuthoritiesConverter();
+        gac.setAuthorityPrefix("SCOPE_");
+        gac.setAuthoritiesClaimName("scope");
+
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(gac);
+        return converter;
+    }
+
+    static class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+        private final String audience;
+
+        AudienceValidator(String audience) {
+            this.audience = audience;
+        }
+
+        @Override
+        public OAuth2TokenValidatorResult validate(Jwt token) {
+            if (token.getAudience().contains(audience)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            OAuth2Error error = new OAuth2Error("invalid_token", "The required audience is missing", null);
+            return OAuth2TokenValidatorResult.failure(error);
+        }
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,7 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/user/permission")
+@RequestMapping("/user/api/permission")
 public class PermissionController {
     private final PermissionService service;
 
@@ -48,6 +49,7 @@ public class PermissionController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Create new permission")
     public ResponseEntity<ApiResponse<PermissionResponse>> create(
             @Validated @RequestBody PermissionCreateRequest request) {
@@ -55,11 +57,12 @@ public class PermissionController {
         return ApiResponse.created(
                 MessageKeys.PERMISSION_CREATED,
                 saved,
-                "/permission/" + saved.id()
+                "/user/api/permission/" + saved.id()
         );
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Update existing permission")
     public ResponseEntity<ApiResponse<PermissionResponse>> update(
             @PathVariable UUID id,
@@ -70,6 +73,7 @@ public class PermissionController {
     }
 
     @PostMapping("/bulk")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Create permissions in bulk")
     public ResponseEntity<ApiResponse<List<PermissionResponse>>> bulkCreate(
             @RequestBody List<@Valid PermissionCreateRequest> requests) {
@@ -77,6 +81,7 @@ public class PermissionController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Delete permission")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable UUID id) {
         return service.delete(id)
@@ -85,6 +90,7 @@ public class PermissionController {
     }
 
     @DeleteMapping("/bulk")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Delete permissions in bulk")
     public ResponseEntity<ApiResponse<Void>> bulkDelete(@RequestBody List<UUID> ids) {
         service.deleteBulk(ids);

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -8,13 +8,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/user/role")
+@RequestMapping("/user/api/role")
 public class RoleController {
     private final RoleService service;
 
@@ -41,6 +42,7 @@ public class RoleController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Create new role")
     public ResponseEntity<ApiResponse<RoleResponse>> create(
             @Validated @RequestBody RoleCreateRequest request) {
@@ -48,11 +50,12 @@ public class RoleController {
         return ApiResponse.created(
                 MessageKeys.ROLE_CREATED,
                 saved,
-                "/role/" + saved.id()
+                "/user/api/role/" + saved.id()
         );
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Update existing role")
     public ResponseEntity<ApiResponse<RoleResponse>> update(@PathVariable UUID id,
                                                             @Validated @RequestBody RoleUpdateRequest request) {
@@ -62,6 +65,7 @@ public class RoleController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Delete role")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable UUID id) {
         return service.delete(id)
@@ -76,6 +80,7 @@ public class RoleController {
     }
 
     @PatchMapping("/{roleId}/permissions/{permId}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Grant or revoke role permission")
     public ResponseEntity<ApiResponse<Void>> toggle(@PathVariable UUID roleId,
                                                     @PathVariable UUID permId,
@@ -85,6 +90,7 @@ public class RoleController {
     }
 
     @PostMapping("/acl-matrix")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Apply bulk permission operations")
     public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody RolePermissionBulkGrantRequest request) {
         service.applyBulk(request.changes());

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -8,12 +8,13 @@ import morning.com.services.user.service.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/user/api")
 public class UserProfileController {
     private final UserProfileService service;
     private final RoleService roleService;
@@ -24,13 +25,14 @@ public class UserProfileController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Create new user profile")
     public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfile profile) {
         UserProfile saved = service.add(profile);
         return ApiResponse.created(
                 MessageKeys.PROFILE_CREATED,
                 saved,
-                "/user/" + saved.getUserId()
+                "/user/api/" + saved.getUserId()
         );
     }
 
@@ -43,6 +45,7 @@ public class UserProfileController {
     }
 
     @PostMapping("/{id}/roles/{roleId}")
+    @PreAuthorize("hasAuthority('SCOPE_user.write')")
     @Operation(summary = "Add role to user")
     public ResponseEntity<ApiResponse<UserProfile>> addRole(@PathVariable UUID id, @PathVariable UUID roleId) {
         if (service.findById(id).isEmpty()) {


### PR DESCRIPTION
## Summary
- add OAuth2 resource server dependency and issuer configuration
- implement SecurityConfig with JWT auth, scope authorities, and audience validation
- protect controller write operations with SCOPE_user.write authority
- move JWT issuer configuration to config-service

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `mvn -q -pl config-service test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0001484b4832d82efaaf6ad92f475