### PR TITLE
Enable JWT-based security in user service

### DIFF
--- a/config-service/src/main/resources/config/user-service-docker.yml
+++ b/config-service/src/main/resources/config/user-service-docker.yml
@@ -37,6 +37,7 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: ${OAUTH_ISSUER_URI:http://auth-service:8080}
+          jwk-set-uri: ${OAUTH_JWK_SET_URI:http://auth-service:8080/.well-known/jwks.json}
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/user-service-docker.yml
+++ b/config-service/src/main/resources/config/user-service-docker.yml
@@ -32,6 +32,11 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${OAUTH_ISSUER_URI:http://auth-service:8080}
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/user-service.yml
+++ b/config-service/src/main/resources/config/user-service.yml
@@ -38,6 +38,11 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${OAUTH_ISSUER_URI:http://localhost:8080}
 
 management:
   tracing:

--- a/config-service/src/main/resources/config/user-service.yml
+++ b/config-service/src/main/resources/config/user-service.yml
@@ -43,6 +43,7 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: ${OAUTH_ISSUER_URI:http://localhost:8080}
+          jwk-set-uri: ${OAUTH_JWK_SET_URI:http://localhost:8080/.well-known/jwks.json}
 
 management:
   tracing:

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -44,6 +44,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>

--- a/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package morning.com.services.user.config;
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/**", "/v3/api-docs/**", "/swagger-ui/**", "/user/public/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
+            );
+        return http.build();
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter converter = new JwtGrantedAuthoritiesConverter();
+        converter.setAuthoritiesClaimName("authorities");
+        converter.setAuthorityPrefix("");
+
+        JwtAuthenticationConverter jwtConverter = new JwtAuthenticationConverter();
+        jwtConverter.setJwtGrantedAuthoritiesConverter(converter);
+        return jwtConverter;
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(OAuth2ResourceServerProperties properties) {
+        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder) JwtDecoders.fromIssuerLocation(properties.getJwt().getIssuerUri());
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(properties.getJwt().getIssuerUri());
+        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, new AudienceValidator("user-service"), new JwtTimestampValidator());
+        jwtDecoder.setJwtValidator(withAudience);
+        return jwtDecoder;
+    }
+
+    static class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+        private final String audience;
+
+        AudienceValidator(String audience) {
+            this.audience = audience;
+        }
+
+        @Override
+        public OAuth2TokenValidatorResult validate(Jwt token) {
+            return token.getAudience().contains(audience) ? OAuth2TokenValidatorResult.success()
+                    : OAuth2TokenValidatorResult.failure(new OAuth2Error("invalid_token", "The required audience is missing", null));
+        }
+    }
+}
+

--- a/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
@@ -48,7 +47,7 @@ public class SecurityConfig {
 
     @Bean
     JwtDecoder jwtDecoder(OAuth2ResourceServerProperties properties) {
-        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder) JwtDecoders.fromIssuerLocation(properties.getJwt().getIssuerUri());
+        NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(properties.getJwt().getJwkSetUri()).build();
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(properties.getJwt().getIssuerUri());
         OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, new AudienceValidator("user-service"), new JwtTimestampValidator());
         jwtDecoder.setJwtValidator(withAudience);

--- a/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/PermissionController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,6 +50,7 @@ public class PermissionController {
 
     @PostMapping
     @Operation(summary = "Create new permission")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<PermissionResponse>> create(
             @Validated @RequestBody PermissionCreateRequest request) {
         PermissionResponse saved = service.add(request);
@@ -61,6 +63,7 @@ public class PermissionController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Update existing permission")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<PermissionResponse>> update(
             @PathVariable UUID id,
             @Validated @RequestBody PermissionUpdateRequest request) {
@@ -71,6 +74,7 @@ public class PermissionController {
 
     @PostMapping("/bulk")
     @Operation(summary = "Create permissions in bulk")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<List<PermissionResponse>>> bulkCreate(
             @RequestBody List<@Valid PermissionCreateRequest> requests) {
         return ApiResponse.success(MessageKeys.SUCCESS, service.addBulk(requests));
@@ -78,6 +82,7 @@ public class PermissionController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete permission")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable UUID id) {
         return service.delete(id)
                 ? ApiResponse.success(MessageKeys.SUCCESS)
@@ -86,6 +91,7 @@ public class PermissionController {
 
     @DeleteMapping("/bulk")
     @Operation(summary = "Delete permissions in bulk")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<Void>> bulkDelete(@RequestBody List<UUID> ids) {
         service.deleteBulk(ids);
         return ApiResponse.success(MessageKeys.SUCCESS);

--- a/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/RoleController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,6 +43,7 @@ public class RoleController {
 
     @PostMapping
     @Operation(summary = "Create new role")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<RoleResponse>> create(
             @Validated @RequestBody RoleCreateRequest request) {
         RoleResponse saved = service.add(request);
@@ -54,6 +56,7 @@ public class RoleController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Update existing role")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<RoleResponse>> update(@PathVariable UUID id,
                                                             @Validated @RequestBody RoleUpdateRequest request) {
         return service.update(id, request)
@@ -63,6 +66,7 @@ public class RoleController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete role")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable UUID id) {
         return service.delete(id)
                 ? ApiResponse.success(MessageKeys.SUCCESS)
@@ -77,6 +81,7 @@ public class RoleController {
 
     @PatchMapping("/{roleId}/permissions/{permId}")
     @Operation(summary = "Grant or revoke role permission")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<Void>> toggle(@PathVariable UUID roleId,
                                                     @PathVariable UUID permId,
                                                     @RequestBody RolePermissionGrantRequest request) {
@@ -86,6 +91,7 @@ public class RoleController {
 
     @PostMapping("/acl-matrix")
     @Operation(summary = "Apply bulk permission operations")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<Void>> applyBulk(@RequestBody RolePermissionBulkGrantRequest request) {
         service.applyBulk(request.changes());
         return ApiResponse.success(MessageKeys.SUCCESS);

--- a/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
+++ b/user-service/src/main/java/morning/com/services/user/controller/UserProfileController.java
@@ -8,6 +8,7 @@ import morning.com.services.user.service.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -25,6 +26,7 @@ public class UserProfileController {
 
     @PostMapping
     @Operation(summary = "Create new user profile")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<UserProfile>> create(@RequestBody UserProfile profile) {
         UserProfile saved = service.add(profile);
         return ApiResponse.created(
@@ -44,6 +46,7 @@ public class UserProfileController {
 
     @PostMapping("/{id}/roles/{roleId}")
     @Operation(summary = "Add role to user")
+    @PreAuthorize("hasAuthority('user:write')")
     public ResponseEntity<ApiResponse<UserProfile>> addRole(@PathVariable UUID id, @PathVariable UUID roleId) {
         if (service.findById(id).isEmpty()) {
             return ApiResponse.error(HttpStatus.NOT_FOUND, MessageKeys.PROFILE_NOT_FOUND);


### PR DESCRIPTION
## Summary
- add spring security oauth2 resource server dependency
- configure JWT resource server with audience check and authorities mapping
- guard write endpoints with method-level authorization

## Testing
- `mvn -q -pl user-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a060615d74832d97c4c31d07048d85