### PR TITLE
Handle unauthorized and forbidden errors

### DIFF
--- a/auth-service/src/main/java/morning/com/services/auth/dto/MessageKeys.java
+++ b/auth-service/src/main/java/morning/com/services/auth/dto/MessageKeys.java
@@ -11,5 +11,7 @@ public final class MessageKeys {
     public static final String ACCOUNT_LOCKED = "auth.account.locked";
     public static final String VALIDATION_ERROR = "auth.validation.error";
     public static final String PASSWORD_CHANGED = "auth.password.changed";
+    public static final String UNAUTHORIZED = "auth.unauthorized";
+    public static final String FORBIDDEN = "auth.forbidden";
 }
 

--- a/auth-service/src/main/java/morning/com/services/auth/exception/ForbiddenException.java
+++ b/auth-service/src/main/java/morning/com/services/auth/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package morning.com.services.auth.exception;
+
+/**
+ * Exception representing an authenticated user lacking sufficient
+ * privileges which should result in a {@code 403 FORBIDDEN} response.
+ */
+public class ForbiddenException extends RuntimeException {
+}

--- a/auth-service/src/main/java/morning/com/services/auth/exception/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/morning/com/services/auth/exception/GlobalExceptionHandler.java
@@ -25,4 +25,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleAccountLocked(AccountLockedException ex) {
         return ApiResponse.error(HttpStatus.LOCKED, MessageKeys.ACCOUNT_LOCKED);
     }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException ex) {
+        return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenException ex) {
+        return ApiResponse.error(HttpStatus.FORBIDDEN, MessageKeys.FORBIDDEN);
+    }
 }

--- a/auth-service/src/main/java/morning/com/services/auth/exception/UnauthorizedException.java
+++ b/auth-service/src/main/java/morning/com/services/auth/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package morning.com.services.auth.exception;
+
+/**
+ * Exception representing an unauthenticated request that should result
+ * in a {@code 401 UNAUTHORIZED} response.
+ */
+public class UnauthorizedException extends RuntimeException {
+}

--- a/user-service/src/main/java/morning/com/services/user/config/JsonAccessDeniedHandler.java
+++ b/user-service/src/main/java/morning/com/services/user/config/JsonAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package morning.com.services.user.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+/**
+ * Writes a JSON body for 403 responses and falls back to 401 when authentication is missing.
+ */
+public class JsonAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        boolean anonymous = authentication == null || authentication instanceof AnonymousAuthenticationToken;
+        response.setStatus(anonymous ? HttpStatus.UNAUTHORIZED.value() : HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        String messageKey = anonymous ? MessageKeys.UNAUTHORIZED : MessageKeys.FORBIDDEN;
+        objectMapper.writeValue(response.getOutputStream(),
+                new ApiResponse<Void>(ApiResponse.ERROR, messageKey, null));
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/config/JsonAuthenticationEntryPoint.java
+++ b/user-service/src/main/java/morning/com/services/user/config/JsonAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package morning.com.services.user.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+/**
+ * Writes a standard JSON body for 401 responses.
+ */
+public class JsonAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(),
+                new ApiResponse<Void>(ApiResponse.ERROR, MessageKeys.UNAUTHORIZED, null));
+    }
+}

--- a/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/morning/com/services/user/config/SecurityConfig.java
@@ -1,8 +1,13 @@
 package morning.com.services.user.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import morning.com.services.user.dto.ApiResponse;
+import morning.com.services.user.dto.MessageKeys;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -22,6 +27,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final ObjectMapper objectMapper;
+
+    public SecurityConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -31,6 +42,18 @@ public class SecurityConfig {
             )
             .oauth2ResourceServer(oauth2 -> oauth2
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((req, res, e) -> {
+                    res.setStatus(HttpStatus.UNAUTHORIZED.value());
+                    res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    objectMapper.writeValue(res.getOutputStream(), new ApiResponse<Void>(ApiResponse.ERROR, MessageKeys.UNAUTHORIZED, null));
+                })
+                .accessDeniedHandler((req, res, e) -> {
+                    res.setStatus(HttpStatus.FORBIDDEN.value());
+                    res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    objectMapper.writeValue(res.getOutputStream(), new ApiResponse<Void>(ApiResponse.ERROR, MessageKeys.FORBIDDEN, null));
+                })
             );
         return http.build();
     }

--- a/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
+++ b/user-service/src/main/java/morning/com/services/user/dto/MessageKeys.java
@@ -14,5 +14,7 @@ public final class MessageKeys {
     public static final String ROLE_NOT_FOUND = "user.role.not_found";
     public static final String PERMISSION_CREATED = "user.permission.created";
     public static final String PERMISSION_NOT_FOUND = "user.permission.not_found";
+    public static final String UNAUTHORIZED = "user.unauthorized";
+    public static final String FORBIDDEN = "user.forbidden";
 }
 

--- a/user-service/src/main/java/morning/com/services/user/exception/ForbiddenException.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package morning.com.services.user.exception;
+
+/**
+ * Exception indicating that an authenticated user lacks required
+ * permissions. It should be translated to a {@code 403 FORBIDDEN}
+ * response.
+ */
+public class ForbiddenException extends RuntimeException {
+}

--- a/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/GlobalExceptionHandler.java
@@ -31,5 +31,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Map<String, String>>> handleIllegalArgument(IllegalArgumentException ex) {
         return ApiResponse.error(HttpStatus.BAD_REQUEST, MessageKeys.VALIDATION_ERROR, Map.of("error", ex.getMessage()));
     }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException ex) {
+        return ApiResponse.error(HttpStatus.UNAUTHORIZED, MessageKeys.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenException ex) {
+        return ApiResponse.error(HttpStatus.FORBIDDEN, MessageKeys.FORBIDDEN);
+    }
 }
 

--- a/user-service/src/main/java/morning/com/services/user/exception/UnauthorizedException.java
+++ b/user-service/src/main/java/morning/com/services/user/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package morning.com.services.user.exception;
+
+/**
+ * Exception indicating that the request lacks valid authentication.
+ * It should be translated to a {@code 401 UNAUTHORIZED} response.
+ */
+public class UnauthorizedException extends RuntimeException {
+}

--- a/user-service/src/test/java/morning/com/services/user/controller/RoleControllerTest.java
+++ b/user-service/src/test/java/morning/com/services/user/controller/RoleControllerTest.java
@@ -3,7 +3,9 @@ package morning.com.services.user.controller;
 import morning.com.services.user.dto.MessageKeys;
 import morning.com.services.user.dto.RoleResponse;
 import morning.com.services.user.exception.FieldValidationException;
+import morning.com.services.user.exception.ForbiddenException;
 import morning.com.services.user.exception.GlobalExceptionHandler;
+import morning.com.services.user.exception.UnauthorizedException;
 import morning.com.services.user.service.RoleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,5 +107,21 @@ class RoleControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.messageKey").value(MessageKeys.VALIDATION_ERROR))
                 .andExpect(jsonPath("$.data.name").value("already exists"));
+    }
+
+    @Test
+    void whenServiceThrowsUnauthorizedReturns401() throws Exception {
+        when(service.search(isNull(), isNull(), isNull(), any())).thenThrow(new UnauthorizedException());
+        mockMvc.perform(get("/user/role"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.UNAUTHORIZED));
+    }
+
+    @Test
+    void whenServiceThrowsForbiddenReturns403() throws Exception {
+        when(service.search(isNull(), isNull(), isNull(), any())).thenThrow(new ForbiddenException());
+        mockMvc.perform(get("/user/role"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.messageKey").value(MessageKeys.FORBIDDEN));
     }
 }


### PR DESCRIPTION
## Summary
- add message keys and handlers for 401/403 errors in auth-service and user-service
- create `UnauthorizedException` and `ForbiddenException` classes
- cover unauthorized and forbidden flows in role controller tests

## Testing
- `mvn -q -pl auth-service,user-service test` *(fails: Non-resolvable parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d03657c8832dbae9672373f6314a